### PR TITLE
Edge sh norm

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -20,6 +20,7 @@ chemical_embedding_irreps_out: 32x0e                                            
 feature_irreps_hidden: 32x0o + 32x0e + 16x1o + 16x1e + 8x2o + 8x2e                # irreps used for hidden features, here we go up to lmax=2, with even and odd parities
 irreps_edge_sh: 0e + 1o + 2e                                                      # irreps of the spherical harmonics used for edges. If a single integer, indicates the full SH up to L_max=that_integer
 conv_to_output_hidden_irreps_out: 16x0e                                           # irreps used in hidden layer of output block
+edge_sh_normalization: integral                                                   # how to normalize the spherical harmonics, integral typically works best, other options are 'norm' and 'component', see e3nn for details
 
 nonlinearity_type: gate                                                           # may be 'gate' or 'norm', 'gate' is recommended
 resnet: false                                                                     # set true to make interaction block a resnet-style update

--- a/configs/full.yaml
+++ b/configs/full.yaml
@@ -21,6 +21,7 @@ chemical_embedding_irreps_out: 32x0e                                            
 feature_irreps_hidden: 32x0o + 32x0e + 16x1o + 16x1e + 8x2o + 8x2e                # irreps used for hidden features, here we go up to lmax=2, with even and odd parities
 irreps_edge_sh: 0e + 1o + 2e                                                      # irreps of the spherical harmonics used for edges. If a single integer, indicates the full SH up to L_max=that_integer
 conv_to_output_hidden_irreps_out: 16x0e                                           # irreps used in hidden layer of output block
+edge_sh_normalization: integral                                                   # how to normalize the spherical harmonics, integral typically works best, other options are 'norm' and 'component', see e3nn for details
 
 nonlinearity_type: gate                                                           # may be 'gate' or 'norm', 'gate' is recommended
 resnet: false                                                                     # set true to make interaction block a resnet-style update

--- a/nequip/nn/embedding/_edge.py
+++ b/nequip/nn/embedding/_edge.py
@@ -29,7 +29,7 @@ class SphericalHarmonicEdgeAttrs(GraphModuleMixin, torch.nn.Module):
     def __init__(
         self,
         irreps_edge_sh: Union[int, str, o3.Irreps],
-        edge_sh_normalization: str = "component",
+        edge_sh_normalization: str = "integral",
         edge_sh_normalize: bool = True,
         irreps_in=None,
         out_field: str = AtomicDataDict.EDGE_ATTRS_KEY,


### PR DESCRIPTION
Make 'integral' the default normalization scheme for the edge-SH-embedding and add it to full.yaml and example.yaml

Note: this requires the yaml PR to be merged first as that contains the full.yaml