### PR TITLE
bug fixed. use class name as default prefix

### DIFF
--- a/nequip/utils/auto_init.py
+++ b/nequip/utils/auto_init.py
@@ -141,7 +141,7 @@ def instantiate(
         return_args_only (bool): if True, do not instantiate, only return the arguments
     """
 
-    prefix_list = [builder.__name__] if inspect.isclass(builder)) else []
+    prefix_list = [builder.__name__] if inspect.isclass(builder) else []
     if isinstance(prefix, str):
         prefix_list += [prefix]
     else:


### PR DESCRIPTION

## Description
builder name is used as the default prefix for instantiating. 

## Motivation and Context
so examples in config files with PerSpecieShift prefixed variables are working

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.