### PR TITLE
Fix config of nonlinearities with wandb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Changed
+- Nonlinearities now specified with `e` and `o` instead of `1` and `-1`
+
+### Fixed
+- Fix specifying nonlinearities when wandb enabled
 
 ## [0.3.2] - 2021-06-09
 ### Added

--- a/configs/full.yaml
+++ b/configs/full.yaml
@@ -25,14 +25,15 @@ conv_to_output_hidden_irreps_out: 16x0e                                         
 nonlinearity_type: gate                                                           # may be 'gate' or 'norm', 'gate' is recommended
 
 # scalar nonlinearities to use — available options are silu, ssp (shifted softplus), tanh, and abs.
-# Different nonlinearities can be specified for 1 (even) and -1 (odd) parity;
-# note that only tanh and abs are correct for -1 (odd parity).
+# Different nonlinearities are specified for e (even) and o (odd) parity;
+# note that only tanh and abs are correct for o (odd parity).
 nonlinearity_scalars:
-  1: ssp
-  -1: tanh
+  e: ssp
+  o: tanh
 nonlinearity_gates:
-  1: ssp
-  -1: abs
+  e: ssp
+  o: abs
+
 resnet: false                                                                     # set true to make interaction block a resnet-style update
 
 num_basis: 8                                                                      # number of basis functions used in the radial basis

--- a/nequip/nn/_convnetlayer.py
+++ b/nequip/nn/_convnetlayer.py
@@ -39,12 +39,22 @@ class ConvNetLayer(GraphModuleMixin, torch.nn.Module):
         num_layers: int = 3,
         resnet: bool = True,
         nonlinearity_type: str = "gate",
-        nonlinearity_scalars: Dict[int, Callable] = {1: "ssp", -1: "tanh"},
-        nonlinearity_gates: Dict[int, Callable] = {1: "ssp", -1: "abs"},
+        nonlinearity_scalars: Dict[int, Callable] = {"e": "ssp", "o": "tanh"},
+        nonlinearity_gates: Dict[int, Callable] = {"e": "ssp", "o": "abs"},
     ):
         super().__init__()
         # initialization
         assert nonlinearity_type in ("gate", "norm")
+        # make the nonlin dicts from parity ints instead of convinience strs
+        nonlinearity_scalars = {
+            1: nonlinearity_scalars["e"],
+            -1: nonlinearity_scalars["o"],
+        }
+        nonlinearity_gates = {
+            1: nonlinearity_gates["e"],
+            -1: nonlinearity_gates["o"],
+        }
+
         self.feature_irreps_hidden = o3.Irreps(feature_irreps_hidden)
         self.resnet = resnet
         self.num_layers = num_layers

--- a/nequip/utils/wandb.py
+++ b/nequip/utils/wandb.py
@@ -5,12 +5,19 @@ from wandb.util import json_friendly_val
 
 
 def init_n_update(config):
+    conf_dict = dict(config)
+    # wandb mangles keys (in terms of type) as well, but we can't easily correct that because there are many ambiguous edge cases. (E.g. string "-1" vs int -1 as keys, are they different config keys?)
+    if any(not isinstance(k, str) for k in conf_dict.keys()):
+        raise TypeError(
+            "Due to wandb limitations, only string keys are supported in configurations."
+        )
+
     # download from wandb set up
     config.run_id = wandb.util.generate_id()
 
     wandb.init(
         project=config.wandb_project,
-        config=dict(config),
+        config=conf_dict,
         name=config.run_name,
         resume="allow",
         id=config.run_id,

--- a/tests/model/test_eng_force.py
+++ b/tests/model/test_eng_force.py
@@ -62,8 +62,8 @@ minimal_config4 = dict(
     PolynomialCutoff_p=6,
     nonlinearity_type="gate",
     # test custom nonlinearities
-    nonlinearity_scalars={1: "silu", -1: "tanh"},
-    nonlinearity_gates={1: "silu", -1: "abs"},
+    nonlinearity_scalars={"e": "silu", "o": "tanh"},
+    nonlinearity_gates={"e": "silu", "o": "abs"},
 )
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Fix specifying nonlinenarities with `wandb` is enabled.

Disallows use of non-string configuration keys, even in nested dicts.

## How Has This Been Tested?
`minimal.yaml` training runs; test suite.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project and has been formatted using `black`.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [X] I have updated `CHANGELOG.md`.