### PR TITLE
Separate validation set option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Most recent change on the bottom.
 - Support for parallel dataloader workers with `dataloader_num_workers`
 - Optionally independently configure validation and training datasets
 
+### Changed
+- Name processed datasets based on a hash of their parameters to ensure only valid cached data is used
+
 ## [0.3.3] - 2021-08-11
 ### Added
 - `to_ase` method in `AtomicData.py` to convert `AtomicData` object to (list of) `ase.Atoms` object(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Most recent change on the bottom.
 ### Added
 - Support for `e3nn`'s `soft_one_hot_linspace` as radial bases
 - Support for parallel dataloader workers with `dataloader_num_workers`
+- Optionally independently configure validation and training datasets
 
 ## [0.3.3] - 2021-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Most recent change on the bottom.
 - Support for `e3nn`'s `soft_one_hot_linspace` as radial bases
 - Support for parallel dataloader workers with `dataloader_num_workers`
 - Optionally independently configure validation and training datasets
+- Save dataset parameters along with processed data
 
 ### Changed
 - Name processed datasets based on a hash of their parameters to ensure only valid cached data is used

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The `nequip-deploy` command is used to deploy the result of a training session i
 It compiles a NequIP model trained in Python to [TorchScript](https://pytorch.org/docs/stable/jit.html).
 The result is an optimized model file that has no dependency on the `nequip` Python library, or even on Python itself:
 ```bash
-nequip-deploy build path/to/training/session/ path/to/deployed.pth
+nequip-deploy build path/to/training/session/ where/to/put/deployed_model.pth
 ```
 For more details on this command, please run `nequip-deploy --help`.
 

--- a/configs/full.yaml
+++ b/configs/full.yaml
@@ -77,6 +77,11 @@ npz_fixed_field_keys:                                                           
 # ase_args:                                                                        # any arguments needed by ase.io.read
 #   format: extxyz
 
+# If you want to use a different dataset for validation, you can specify
+# the same types of options using a `validation_` prefix:
+# validation_dataset: ase
+# validation_dataset_file_name: xxx.xyz                                                       # need to be a format accepted by ase.io.read
+
 # logging
 wandb: false                                                                        # we recommend using wandb for logging, we'll turn it off here as it's optional
 wandb_project: aspirin                                                             # project name used in wandb

--- a/examples/monkeypatch.py
+++ b/examples/monkeypatch.py
@@ -59,6 +59,7 @@ sgn.insert_from_parameters(
 # Load the original config file --- this could be a new one too:
 config = Config.from_file(path + "/config_final.yaml")
 # Load the dataset:
+# (Note that this loads the training dataset if there are separate training and validation datasets defined.)
 dataset = dataset_from_config(config)
 
 # Evaluate the model on a configuration:

--- a/nequip/data/dataset.py
+++ b/nequip/data/dataset.py
@@ -149,7 +149,7 @@ class AtomicInMemoryDataset(AtomicDataset):
         return params
 
     @property
-    def processed_file_names(self):
+    def processed_dir(self) -> str:
         # We want the file name to change when the parameters change
         # So, first we get all parameters:
         params = self._get_parameters()
@@ -160,7 +160,11 @@ class AtomicInMemoryDataset(AtomicDataset):
         buffer = yaml.dump(params).encode("ascii")
         # And hash it:
         param_hash = hashlib.sha1(buffer).hexdigest()
-        return [f"dataset_{param_hash}.pth"]
+        return f"{self.root}/processed_dataset_{param_hash}"
+
+    @property
+    def processed_file_names(self) -> List[str]:
+        return ["data.pth"]
 
     def get_data(
         self,

--- a/nequip/data/dataset.py
+++ b/nequip/data/dataset.py
@@ -164,7 +164,7 @@ class AtomicInMemoryDataset(AtomicDataset):
 
     @property
     def processed_file_names(self) -> List[str]:
-        return ["data.pth", "params.pth"]
+        return ["data.pth", "params.yaml"]
 
     def get_data(
         self,
@@ -288,7 +288,8 @@ class AtomicInMemoryDataset(AtomicDataset):
         logging.info(f"Loaded data: {data}")
 
         torch.save((data, fixed_fields, self.include_frames), self.processed_paths[0])
-        torch.save(self._get_parameters(), self.processed_paths[1])
+        with open(self.processed_paths[1], "w") as f:
+            yaml.dump(self._get_parameters(), f)
 
         self.data = data
         self.fixed_fields = fixed_fields

--- a/nequip/data/dataset.py
+++ b/nequip/data/dataset.py
@@ -7,6 +7,9 @@ This module requre the torch_geometric to catch up with the github main branch f
 import numpy as np
 import logging
 import tempfile
+import inspect
+import yaml
+import hashlib
 from os.path import dirname, basename, abspath
 from typing import Tuple, Dict, Any, List, Callable, Union, Optional, Sequence
 
@@ -15,6 +18,7 @@ import ase
 import torch
 from torch_geometric.data import Batch, Dataset, download_url, extract_zip
 
+import nequip
 from nequip.data import AtomicData, AtomicDataDict
 from ._util import _TORCH_INTEGER_DTYPES
 
@@ -85,7 +89,7 @@ class AtomicInMemoryDataset(AtomicDataset):
         extra_fixed_fields: Dict[str, Any] = {},
         include_frames: Optional[List[int]] = None,
     ):
-        # TO DO, this may be symplified
+        # TO DO, this may be simplified
         # See if a subclass defines some inputs
         self.file_name = (
             getattr(type(self), "FILE_NAME", None) if file_name is None else file_name
@@ -135,14 +139,28 @@ class AtomicInMemoryDataset(AtomicDataset):
     def raw_file_names(self):
         raise NotImplementedError()
 
+    def _get_parameters(self) -> Dict[str, Any]:
+        """Get a dict of the parameters used to build this dataset."""
+        pnames = list(inspect.signature(self.__init__).parameters)
+        params = {k: getattr(self, k) for k in pnames if hasattr(self, k)}
+        # Add other relevant metadata:
+        params["dtype"] = str(torch.get_default_dtype())
+        params["nequip_version"] = nequip.__version__
+        return params
+
     @property
     def processed_file_names(self):
-        # TO DO, can be updated to hash all simple terms in extra_fixed_fields
-        r_max = self.extra_fixed_fields["r_max"]
-        dtype = str(torch.get_default_dtype())
-        if dtype.startswith("torch."):
-            dtype = dtype[len("torch.") :]
-        return [f"{r_max}_{dtype}_data.pt"]
+        # We want the file name to change when the parameters change
+        # So, first we get all parameters:
+        params = self._get_parameters()
+        # Make some kind of string of them:
+        # we don't care about this possibly changing between python versions,
+        # since a change in python version almost certainly means a change in
+        # versions of other things too, and is a good reason to recompute
+        buffer = yaml.dump(params).encode("ascii")
+        # And hash it:
+        param_hash = hashlib.sha1(buffer).hexdigest()
+        return [f"dataset_{param_hash}.pth"]
 
     def get_data(
         self,

--- a/nequip/data/dataset.py
+++ b/nequip/data/dataset.py
@@ -164,7 +164,7 @@ class AtomicInMemoryDataset(AtomicDataset):
 
     @property
     def processed_file_names(self) -> List[str]:
-        return ["data.pth"]
+        return ["data.pth", "params.pth"]
 
     def get_data(
         self,
@@ -288,6 +288,7 @@ class AtomicInMemoryDataset(AtomicDataset):
         logging.info(f"Loaded data: {data}")
 
         torch.save((data, fixed_fields, self.include_frames), self.processed_paths[0])
+        torch.save(self._get_parameters(), self.processed_paths[1])
 
         self.data = data
         self.fixed_fields = fixed_fields

--- a/nequip/scripts/restart.py
+++ b/nequip/scripts/restart.py
@@ -80,10 +80,19 @@ def restart(file_name, config, mode="update"):
 
     config.update(trainer.output.updated_dict())
 
-    dataset = dataset_from_config(config)
-    logging.info(f"Successfully reload the data set of type {dataset}...")
+    # = Load the dataset =
+    dataset = dataset_from_config(config, prefix="dataset")
+    logging.info(f"Successfully re-loaded the data set of type {dataset}...")
+    try:
+        validation_dataset = dataset_from_config(config, prefix="validation_dataset")
+        logging.info(
+            f"Successfully re-loaded the validation data set of type {validation_dataset}..."
+        )
+    except KeyError:
+        # It couldn't be found
+        validation_dataset = None
+    trainer.set_dataset(dataset, validation_dataset)
 
-    trainer.set_dataset(dataset)
     trainer.train()
 
     return

--- a/nequip/scripts/train.py
+++ b/nequip/scripts/train.py
@@ -118,11 +118,19 @@ def fresh_start(config):
     config.update(output.updated_dict())
 
     # = Load the dataset =
-    dataset = dataset_from_config(config)
+    dataset = dataset_from_config(config, prefix="dataset")
     logging.info(f"Successfully loaded the data set of type {dataset}...")
+    try:
+        validation_dataset = dataset_from_config(config, prefix="validation_dataset")
+        logging.info(
+            f"Successfully loaded the validation data set of type {validation_dataset}..."
+        )
+    except KeyError:
+        # It couldn't be found
+        validation_dataset = None
 
     # = Train/test split =
-    trainer.set_dataset(dataset)
+    trainer.set_dataset(dataset, validation_dataset)
 
     # = Determine training type =
     train_on = config.loss_coeffs

--- a/tests/unit/data/test_dataset.py
+++ b/tests/unit/data/test_dataset.py
@@ -139,18 +139,23 @@ class TestStatistics:
 class TestReload:
     @pytest.mark.parametrize("change_rmax", [0, 1])
     @pytest.mark.parametrize("give_url", [True, False])
-    def test_reload(self, npz_dataset, npz_data, change_rmax, give_url):
+    @pytest.mark.parametrize("change_key_map", [True, False])
+    def test_reload(self, npz_dataset, npz_data, change_rmax, give_url, change_key_map):
         r_max = npz_dataset.extra_fixed_fields["r_max"] + change_rmax
+        keymap = npz_dataset.key_mapping.copy()  # the default one
+        if change_key_map:
+            keymap["x1"] = "x2"
         a = NpzDataset(
             file_name=npz_data,
             root=npz_dataset.root,
             extra_fixed_fields={"r_max": r_max},
+            key_mapping=keymap,
             **({"url": "example.com/data.dat"} if give_url else {})
         )
         print(a.processed_file_names[0])
         print(npz_dataset.processed_file_names[0])
         assert (a.processed_dir == npz_dataset.processed_dir) == (
-            change_rmax == 0 and not give_url
+            (change_rmax == 0) and (not give_url) and (not change_key_map)
         )
 
 

--- a/tests/unit/data/test_dataset.py
+++ b/tests/unit/data/test_dataset.py
@@ -138,16 +138,20 @@ class TestStatistics:
 
 class TestReload:
     @pytest.mark.parametrize("change_rmax", [0, 1])
-    def test_reload(self, npz_dataset, npz_data, change_rmax):
+    @pytest.mark.parametrize("give_url", [True, False])
+    def test_reload(self, npz_dataset, npz_data, change_rmax, give_url):
         r_max = npz_dataset.extra_fixed_fields["r_max"] + change_rmax
         a = NpzDataset(
             file_name=npz_data,
             root=npz_dataset.root,
             extra_fixed_fields={"r_max": r_max},
+            **({"url": "example.com/data.dat"} if give_url else {})
         )
         print(a.processed_file_names[0])
         print(npz_dataset.processed_file_names[0])
-        assert (a.processed_dir == npz_dataset.processed_dir) == (change_rmax == 0)
+        assert (a.processed_dir == npz_dataset.processed_dir) == (
+            change_rmax == 0 and not give_url
+        )
 
 
 class TestFromConfig:

--- a/tests/unit/data/test_dataset.py
+++ b/tests/unit/data/test_dataset.py
@@ -167,17 +167,18 @@ class TestFromConfig:
         assert isdir(g.root)
         assert isdir(f"{g.root}/processed")
 
-    def test_ase(self, ase_file, root):
+    @pytest.mark.parametrize("prefix", ["dataset", "thingy"])
+    def test_ase(self, ase_file, root, prefix):
         config = Config(
             dict(
-                dataset="ASEDataset",
                 file_name=ase_file,
                 root=root,
                 extra_fixed_fields={"r_max": 3.0},
                 ase_args=dict(format="extxyz"),
             )
         )
-        a = dataset_from_config(config)
+        config[prefix] = "ASEDataset"
+        a = dataset_from_config(config, prefix=prefix)
         assert isdir(a.root)
         assert isdir(f"{a.root}/processed")
 

--- a/tests/unit/data/test_dataset.py
+++ b/tests/unit/data/test_dataset.py
@@ -193,6 +193,15 @@ class TestFromConfig:
         assert isdir(a.processed_dir)
         assert isfile(a.processed_dir + "/data.pth")
 
+        # Test reload
+        # Change some random ASE specific parameter
+        # See https://wiki.fysik.dtu.dk/ase/ase/io/io.html
+        config["ase_args"]["do_not_split_by_at_sign"] = True
+        b = dataset_from_config(config, prefix=prefix)
+        assert isdir(b.processed_dir)
+        assert isfile(b.processed_dir + "/data.pth")
+        assert a.processed_dir != b.processed_dir
+
 
 class TestFromList:
     def test_from_atoms(self, molecules):

--- a/tests/unit/data/test_dataset.py
+++ b/tests/unit/data/test_dataset.py
@@ -3,7 +3,7 @@ import pytest
 import tempfile
 import torch
 
-from os.path import isdir
+from os.path import isdir, isfile
 
 from ase.io import write
 
@@ -68,7 +68,8 @@ class TestInit:
     def test_npz(self, npz_data, root):
         g = NpzDataset(file_name=npz_data, root=root, extra_fixed_fields={"r_max": 3.0})
         assert isdir(g.root)
-        assert isdir(f"{g.root}/processed")
+        assert isdir(g.processed_dir)
+        assert isfile(g.processed_dir + "/data.pth")
 
     def test_ase(self, ase_file, root):
         a = ASEDataset(
@@ -78,7 +79,8 @@ class TestInit:
             ase_args=dict(format="extxyz"),
         )
         assert isdir(a.root)
-        assert isdir(f"{a.root}/processed")
+        assert isdir(a.processed_dir)
+        assert isfile(a.processed_dir + "/data.pth")
 
 
 class TestStatistics:
@@ -145,9 +147,7 @@ class TestReload:
         )
         print(a.processed_file_names[0])
         print(npz_dataset.processed_file_names[0])
-        assert (a.processed_file_names[0] == npz_dataset.processed_file_names[0]) == (
-            change_rmax == 0
-        )
+        assert (a.processed_dir == npz_dataset.processed_dir) == (change_rmax == 0)
 
 
 class TestFromConfig:
@@ -165,7 +165,8 @@ class TestFromConfig:
         g = dataset_from_config(config)
         assert g.fixed_fields["r_max"] == 3
         assert isdir(g.root)
-        assert isdir(f"{g.root}/processed")
+        assert isdir(g.processed_dir)
+        assert isfile(g.processed_dir + "/data.pth")
 
     @pytest.mark.parametrize("prefix", ["dataset", "thingy"])
     def test_ase(self, ase_file, root, prefix):
@@ -180,7 +181,8 @@ class TestFromConfig:
         config[prefix] = "ASEDataset"
         a = dataset_from_config(config, prefix=prefix)
         assert isdir(a.root)
-        assert isdir(f"{a.root}/processed")
+        assert isdir(a.processed_dir)
+        assert isfile(a.processed_dir + "/data.pth")
 
 
 class TestFromList:

--- a/tests/unit/datasets/test_simplesets.py
+++ b/tests/unit/datasets/test_simplesets.py
@@ -29,6 +29,6 @@ def test_simple(name, temp_data, BENCHMARK_ROOT):
     print(a.data)
     print(a.fixed_fields)
     assert isdir(config.root)
-    assert isdir(f"{config.root}/processed")
+    assert isdir(a.processed_dir)
     assert len(a.data.edge_index) == len(include_frames)
-    rmtree(f"{config.root}/processed")
+    rmtree(a.processed_dir)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Option to specify a completely different dataset to sample validation set from. By default behavior of sampling both from one dataset in non-overlapping way is maintained.

## Motivation and Context
Avoid lots of wasted time calling `nequip-evaluate` during some trainings.

## How Has This Been Tested?
Existing unit tests pass, should write new ones.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project and has been formatted using `black`.
- [X] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [X] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [X] I have updated `CHANGELOG.md`.