### PR TITLE
Hot fix for the early stopping typo

### DIFF
--- a/nequip/train/trainer.py
+++ b/nequip/train/trainer.py
@@ -777,7 +777,7 @@ class Trainer:
             if debug_args is not None:
                 self.logger.debug(debug_args)
             if early_stop:
-                self.stop_args = early_stop_args
+                self.stop_arg = early_stop_args
                 return True
 
         if self.iepoch >= self.max_epochs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

Remove the typo for the stop_arg in Trainer