### PR TITLE
Add before option to the SequentialGraphNetwork insert method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Most recent change on the bottom.
 - Arbitrary atom type support
 - Unified, modular model building and initialization architecture
 - Added `nequip-benchmark` script for benchmarking and profiling models
+- Add before option to SequentialGraphNetwork.insert
 
 ### Changed
 - Name processed datasets based on a hash of their parameters to ensure only valid cached data is used

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -295,7 +295,7 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             insert_location = after
         else:
             insert_location = before
-        idx = list(self._modules.keys()).index(insert_location)-1
+        idx = list(self._modules.keys()).index(insert_location) - 1
         if before is None:
             idx += 1
         instance, _ = instantiate(

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -253,7 +253,7 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             raise ValueError("Only one of before or after argument needs to be defined")
         elif before is None:
             insert_location = after
-        elif before is None:
+        else:
             insert_location = before
 
         # This checks names, etc.
@@ -293,7 +293,7 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             raise ValueError("Only one of before or after argument needs to be defined")
         elif before is None:
             insert_location = after
-        elif before is None:
+        else:
             insert_location = before
         idx = list(self._modules.keys()).index(insert_location)-1
         if before is None:

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -295,9 +295,9 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             insert_location = after
         elif before is None:
             insert_location = before
-        idx = list(self._modules.keys()).index(insert_location)
+        idx = list(self._modules.keys()).index(insert_location)-1
         if before is None:
-            idx -= 1
+            idx += 1
         instance, _ = instantiate(
             builder=builder,
             prefix=name,

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -233,44 +233,71 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
         self.append(name, instance)
         return
 
-    def insert(self, after: str, name: str, module: GraphModuleMixin) -> None:
+    def insert(
+        self,
+        name: str,
+        module: GraphModuleMixin,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+    ) -> None:
         """Insert a module after the module with name ``after``.
 
         Args:
-            after: the module to insert after
             name: the name of the module to insert
             module: the moldule to insert
+            after: the module to insert after
+            before: the module to insert before
         """
+
+        if before is None == after is None:
+            raise ValueError("Only one of before or after argument needs to be defined")
+        elif before is None:
+            insert_location = after
+        elif before is None:
+            insert_location = before
+
         # This checks names, etc.
         self.add_module(name, module)
         # Now insert in the right place by overwriting
         names = list(self._modules.keys())
         modules = list(self._modules.values())
-        idx = names.index(after)
-        names.insert(idx + 1, name)
-        modules.insert(idx + 1, module)
+        idx = names.index(insert_location)
+        if before is None:
+            idx += 1
+        names.insert(idx, name)
+        modules.insert(idx, module)
         self._modules = OrderedDict(zip(names, modules))
         # TODO: handle irreps
         return
 
     def insert_from_parameters(
         self,
-        after: str,
         shared_params: Mapping,
         name: str,
         builder: Callable,
         params: Dict[str, Any] = {},
+        after: Optional[str] = None,
+        before: Optional[str] = None,
     ) -> None:
         r"""Build a module from parameters and insert it after ``after``.
 
         Args:
-            after: the name of the module to insert after
             shared_params (dict-like): shared parameters from which to pull when instantiating the module
             name (str): the name for the module
             builder (callable): a class or function to build a module
             params (dict, optional): extra specific parameters for this module that take priority over those in ``shared_params``
+            after: the name of the module to insert after
+            before: the name of the module to insert before
         """
-        idx = list(self._modules.keys()).index(after)
+        if before is None == after is None:
+            raise ValueError("Only one of before or after argument needs to be defined")
+        elif before is None:
+            insert_location = after
+        elif before is None:
+            insert_location = before
+        idx = list(self._modules.keys()).index(insert_location)
+        if before is None:
+            idx -= 1
         instance, _ = instantiate(
             builder=builder,
             prefix=name,
@@ -278,7 +305,7 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             optional_args=params,
             all_args=shared_params,
         )
-        self.insert(after, name, instance)
+        self.insert(after=after, before=before, name=name, module=instance)
         return
 
     # Copied from https://pytorch.org/docs/stable/_modules/torch/nn/modules/container.html#Sequential

--- a/tests/unit/nn/test_sequential.py
+++ b/tests/unit/nn/test_sequential.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from nequip.data import AtomicDataDict
@@ -39,14 +40,15 @@ def test_append():
     )
     assert out["thing"].shape == out[AtomicDataDict.NODE_FEATURES_KEY].shape
 
-
-def test_insert():
+@pytest.mark.parametrize("mode", {"before", "after"})
+def test_insert(mode):
     sgn = SequentialGraphNetwork.from_parameters(
         shared_params={"num_types": 3},
         layers={"one_hot": OneHotAtomEncoding, "lin2": AtomwiseLinear},
     )
+    keys = {"before":"lin2", "after":"one_hot"}
     sgn.insert_from_parameters(
-        after="one_hot",
+        **{mode:keys[mode]},
         shared_params={"out_field": "thing"},
         name="lin1",
         builder=AtomwiseLinear,

--- a/tests/unit/nn/test_sequential.py
+++ b/tests/unit/nn/test_sequential.py
@@ -40,15 +40,16 @@ def test_append():
     )
     assert out["thing"].shape == out[AtomicDataDict.NODE_FEATURES_KEY].shape
 
+
 @pytest.mark.parametrize("mode", {"before", "after"})
 def test_insert(mode):
     sgn = SequentialGraphNetwork.from_parameters(
         shared_params={"num_types": 3},
         layers={"one_hot": OneHotAtomEncoding, "lin2": AtomwiseLinear},
     )
-    keys = {"before":"lin2", "after":"one_hot"}
+    keys = {"before": "lin2", "after": "one_hot"}
     sgn.insert_from_parameters(
-        **{mode:keys[mode]},
+        **{mode: keys[mode]},
         shared_params={"out_field": "thing"},
         name="lin1",
         builder=AtomwiseLinear,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
as described above

## Motivation and Context
So we can insert to the network sequence based on the before/after module name

## How Has This Been Tested?
in tests/unit/nn/test_sequential, a parameter is added to the test_insert function to test out both options.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [x] I have updated `CHANGELOG.md`.