### PR TITLE
Fix requeue mode on develop branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Most recent change on the bottom.
 - Model builder to initialize training from previous checkpoint
 - Better error when instantiation fails
 - Rename `npz_keys` to `include_keys`
+- Allow user to register `graph_fields`, `node_fields`, and `edge_fields` via yaml
 
 ### Changed
 - Name processed datasets based on a hash of their parameters to ensure only valid cached data is used
@@ -36,6 +37,7 @@ data
 - Renamed `trainable_global_rescale_scale` to `global_rescale_scale_trainble`
 - Renamed `trainable_global_rescale_shift` to `global_rescale_shift_trainble`
 - Renamed `PerSpeciesScaleShift_` to `per_species_rescale`
+- Change default and allowed values of `metrics_key` from `loss` to `validation_loss`. The old default `loss` will no longer be accepted.
 
 ### Fixed
 - The first 20 epochs/calls of inference are no longer painfully slow for recompilation

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -82,7 +82,7 @@ batch_size: 5                                                                   
 max_epochs: 100000                                                                 # stop training after _ number of epochs, we set a very large number here, it won't take this long in practice and we will use early stopping instead
 train_val_split: random                                                            # can be random or sequential. if sequential, first n_train elements are training, next n_val are val, else random, usually random is the right choice
 shuffle: true                                                                      # If true, the data loader will shuffle the data, usually a good idea
-metrics_key: loss                                                                  # metrics used for scheduling and saving best model. Options: loss, or anything that appears in the validation batch step header, such as f_mae, f_rmse, e_mae, e_rmse
+metrics_key: validation_loss                                                       # metrics used for scheduling and saving best model. Options: `set`_`quantity`, set can be either "train" or "validation, "quantity" can be loss or anything that appears in the validation batch step header, such as f_mae, f_rmse, e_mae, e_rmse
 use_ema: true                                                                      # if true, use exponential moving average on weights for val/test, usually helps a lot with training, in particular for energy errors
 ema_decay: 0.99                                                                    # ema weight, typically set to 0.99 or 0.999
 ema_use_num_updates: true                                                          # whether to use number of updates when computing averages

--- a/configs/full.yaml
+++ b/configs/full.yaml
@@ -130,7 +130,7 @@ batch_size: 5                                                                   
 max_epochs: 100000                                                                      # stop training after _ number of epochs, we set a very large number here, it won't take this long in practice and we will use early stopping instead
 train_val_split: random                                                            # can be random or sequential. if sequential, first n_train elements are training, next n_val are val, else random, usually random is the right choice
 shuffle: true                                                                      # If true, the data loader will shuffle the data, usually a good idea
-metrics_key: loss                                                                  # metrics used for scheduling and saving best model. Options: loss, or anything that appears in the validation batch step header, such as f_mae, f_rmse, e_mae, e_rmse
+metrics_key: valitaion_loss                                                        # metrics used for scheduling and saving best model. Options: `set`_`quantity`, set can be either "train" or "validation, "quantity" can be loss or anything that appears in the validation batch step header, such as f_mae, f_rmse, e_mae, e_rmse
 use_ema: true                                                                      # if true, use exponential moving average on weights for val/test, usually helps a lot with training, in particular for energy errors
 ema_decay: 0.99                                                                    # ema weight, typically set to 0.99 or 0.999
 ema_use_num_updates: true                                                          # whether to use number of updates when computing averages

--- a/nequip/data/AtomicData.py
+++ b/nequip/data/AtomicData.py
@@ -66,12 +66,14 @@ def register_fields(
     graph_fields: set = set(graph_fields)
     allfields = node_fields.union(edge_fields, graph_fields)
     assert len(allfields) == len(node_fields) + len(edge_fields) + len(graph_fields)
-    assert (_NODE_FIELDS.union(_EDGE_FIELDS, _GRAPH_FIELDS)).isdisjoint(
-        allfields
-    ), "Cannot reregister a field that has already been registered"
     _NODE_FIELDS.update(node_fields)
     _EDGE_FIELDS.update(edge_fields)
     _GRAPH_FIELDS.update(graph_fields)
+    multiregistered = _NODE_FIELDS.intersection(_EDGE_FIELDS, _GRAPH_FIELDS)
+    if len(multiregistered) > 0:
+        raise ValueError(
+            f"Tried to register keys `{multiregistered}` as more than one of node, edge, or graph!"
+        )
 
 
 def deregister_fields(*fields: Sequence[str]) -> None:

--- a/nequip/data/AtomicData.py
+++ b/nequip/data/AtomicData.py
@@ -69,10 +69,11 @@ def register_fields(
     _NODE_FIELDS.update(node_fields)
     _EDGE_FIELDS.update(edge_fields)
     _GRAPH_FIELDS.update(graph_fields)
-    multiregistered = _NODE_FIELDS.intersection(_EDGE_FIELDS, _GRAPH_FIELDS)
-    if len(multiregistered) > 0:
+    if len(set.union(_NODE_FIELDS, _EDGE_FIELDS, _GRAPH_FIELDS)) < (
+        len(_NODE_FIELDS) + len(_EDGE_FIELDS) + len(_GRAPH_FIELDS)
+    ):
         raise ValueError(
-            f"Tried to register keys `{multiregistered}` as more than one of node, edge, or graph!"
+            "At least one key was registered as more than one of node, edge, or graph!"
         )
 
 

--- a/nequip/data/_build.py
+++ b/nequip/data/_build.py
@@ -57,29 +57,25 @@ def dataset_from_config(config, prefix: str = "dataset") -> AtomicDataset:
         raise NameError(f"dataset type {dataset_name} does not exists")
 
     # if dataset r_max is not found, use the universal r_max
-    extra_fixed_fields_key = prefix + "_extra_fixed_fields"
-    if extra_fixed_fields_key not in config:
-        config[extra_fixed_fields_key] = {}
-        if "extra_fixed_fields" in config:
-            config[extra_fixed_fields_key].update(config.extra_fixed_fields)
-
-    if "r_max" in config and "r_max" not in config[extra_fixed_fields_key]:
-        config[extra_fixed_fields_key]["r_max"] = config.r_max
+    eff_key = "extra_fixed_fields"
+    prefixed_eff_key = f"{prefix}_{eff_key}"
+    config[prefixed_eff_key] = get_w_prefix(
+        eff_key, {}, prefix=prefix, arg_dicts=config
+    )
+    config[prefixed_eff_key]["r_max"] = get_w_prefix(
+        "r_max",
+        prefix=prefix,
+        arg_dicts=[config[prefixed_eff_key], config],
+    )
 
     # Build a TypeMapper from the config
     type_mapper, _ = instantiate(TypeMapper, prefix=prefix, optional_args=config)
 
     # Register fields:
     register_fields(
-        node_fields=get_w_prefix(
-            "node_fields", [], prefix=[prefix], arg_dicts=[config]
-        ),
-        edge_fields=get_w_prefix(
-            "edge_fields", [], prefix=[prefix], arg_dicts=[config]
-        ),
-        graph_fields=get_w_prefix(
-            "graph_fields", [], prefix=[prefix], arg_dicts=[config]
-        ),
+        node_fields=get_w_prefix("node_fields", [], prefix=prefix, arg_dicts=config),
+        edge_fields=get_w_prefix("edge_fields", [], prefix=prefix, arg_dicts=config),
+        graph_fields=get_w_prefix("graph_fields", [], prefix=prefix, arg_dicts=config),
     )
 
     instance, _ = instantiate(

--- a/nequip/data/_build.py
+++ b/nequip/data/_build.py
@@ -73,9 +73,9 @@ def dataset_from_config(config, prefix: str = "dataset") -> AtomicDataset:
 
     # Register fields:
     register_fields(
-        node_fields=get_w_prefix("node_fields", [], prefix=prefix, arg_dicts=config),
-        edge_fields=get_w_prefix("edge_fields", [], prefix=prefix, arg_dicts=config),
-        graph_fields=get_w_prefix("graph_fields", [], prefix=prefix, arg_dicts=config),
+        node_fields=config.get("node_fields", []),
+        edge_fields=config.get("edge_fields", []),
+        graph_fields=config.get("graph_fields", []),
     )
 
     instance, _ = instantiate(

--- a/nequip/data/_build.py
+++ b/nequip/data/_build.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from nequip import data
 from nequip.data.transforms import TypeMapper
 from nequip.data import AtomicDataset, register_fields
-from nequip.utils import instantiate
+from nequip.utils import instantiate, get_w_prefix
 
 
 def dataset_from_config(config, prefix: str = "dataset") -> AtomicDataset:
@@ -71,9 +71,15 @@ def dataset_from_config(config, prefix: str = "dataset") -> AtomicDataset:
 
     # Register fields:
     register_fields(
-        node_fields=config.get(f"{prefix}_node_fields", []),
-        edge_fields=config.get(f"{prefix}_edge_fields", []),
-        graph_fields=config.get(f"{prefix}_graph_fields", []),
+        node_fields=get_w_prefix(
+            "node_fields", [], prefix=[prefix], arg_dicts=[config]
+        ),
+        edge_fields=get_w_prefix(
+            "edge_fields", [], prefix=[prefix], arg_dicts=[config]
+        ),
+        graph_fields=get_w_prefix(
+            "graph_fields", [], prefix=[prefix], arg_dicts=[config]
+        ),
     )
 
     instance, _ = instantiate(

--- a/nequip/model/_scaling.py
+++ b/nequip/model/_scaling.py
@@ -5,6 +5,7 @@ import torch
 
 from nequip.nn import RescaleOutput, GraphModuleMixin, PerSpeciesScaleShift
 from nequip.data import AtomicDataDict, AtomicDataset
+from nequip.utils import get_w_prefix
 
 
 RESCALE_THRESHOLD = 1e-6
@@ -31,7 +32,7 @@ def RescaleEnergyEtc(
         prefix=module_prefix,
         arg_dicts=config,
     )
-    global_shift = get_w_prefx(
+    global_shift = get_w_prefix(
         f"{module_prefix}_shift", None, prefix=module_prefix, arg_dicts=config
     )
 

--- a/nequip/model/_scaling.py
+++ b/nequip/model/_scaling.py
@@ -23,13 +23,17 @@ def RescaleEnergyEtc(
 
     module_prefix = "global_rescale"
 
-    global_scale = config.get(
-        f"{module_prefix}_scale",
+    global_scale = get_w_prefix(
+        "scale",
         f"dataset_{AtomicDataDict.FORCE_KEY}_rms"
         if AtomicDataDict.FORCE_KEY in model.irreps_out
         else f"dataset_{AtomicDataDict.TOTAL_ENERGY_KEY}_std",
+        prefix=module_prefix,
+        arg_dicts=config,
     )
-    global_shift = config.get(f"{module_prefix}_shift", None)
+    global_shift = get_w_prefx(
+        f"{module_prefix}_shift", None, prefix=module_prefix, arg_dicts=config
+    )
 
     if global_shift is not None:
         logging.warning(
@@ -102,8 +106,12 @@ def RescaleEnergyEtc(
             k for k in (AtomicDataDict.TOTAL_ENERGY_KEY,) if k in model.irreps_out
         ],
         shift_by=global_shift,
-        shift_trainable=config.get(f"{module_prefix}_shift_trainable", False),
-        scale_trainable=config.get(f"{module_prefix}_scale_trainable", False),
+        shift_trainable=get_w_prefix(
+            "shift_trainable", False, prefix=module_prefix, arg_dicts=config
+        ),
+        scale_trainable=get_w_prefix(
+            "scale_trainable", False, prefix=module_prefix, arg_dicts=config
+        ),
     )
 
 
@@ -120,15 +128,19 @@ def PerSpeciesRescale(
     module_prefix = "per_species_rescale"
 
     # = Determine energy rescale type =
-    scales = config.get(
-        module_prefix + "_scales",
+    scales = get_w_prefix(
+        "scales",
         f"dataset_{AtomicDataDict.FORCE_KEY}_rms"
         if AtomicDataDict.FORCE_KEY in config["train_on_keys"]
         else f"dataset_per_atom_{AtomicDataDict.TOTAL_ENERGY_KEY}_std",
+        prefix=module_prefix,
+        arg_dicts=config,
     )
-    shifts = config.get(
-        module_prefix + "_shifts",
+    shifts = get_w_prefix(
+        "shifts",
         f"dataset_per_atom_{AtomicDataDict.TOTAL_ENERGY_KEY}_mean",
+        prefix=module_prefix,
+        arg_dicts=config,
     )
 
     # = Determine what statistics need to be compute =\

--- a/nequip/train/_key.py
+++ b/nequip/train/_key.py
@@ -7,12 +7,13 @@ LOSS_KEY = "noramlized_loss"
 VALUE_KEY = "value"
 CONTRIB = "contrib"
 
-VALIDATION = "Validation"
-TRAIN = "Training"
+VALIDATION = "validation"
+TRAIN = "training"
 
 ABBREV = {
     AtomicDataDict.TOTAL_ENERGY_KEY: "e",
     AtomicDataDict.FORCE_KEY: "f",
     LOSS_KEY: "loss",
     VALIDATION: "val",
+    TRAIN: "train",
 }

--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -164,13 +164,13 @@ def find_loss_function(name: str, params):
     """
 
     wrapper_list = dict(
-        PerSpecies=PerSpeciesLoss,
-        PerAtom=PerAtomLoss,
+        perspecies=PerSpeciesLoss,
+        peratom=PerAtomLoss,
     )
 
     if isinstance(name, str):
         for key in wrapper_list:
-            if name.startswith(key):
+            if name.lower().startswith(key):
                 logging.debug(f"create loss instance {wrapper_list[key]}")
                 return wrapper_list[key](name[len(key) :], params)
         return SimpleLoss(name, params)

--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 
 import torch.nn
@@ -172,7 +173,8 @@ def find_loss_function(name: str, params):
             if name.startswith(key):
                 logging.debug(f"create loss instance {wrapper_list[key]}")
                 return wrapper_list[key](name[len(key) :], params)
-
+        return SimpleLoss(name, params)
+    elif inspect.isclass(name):
         return SimpleLoss(name, params)
     elif callable(name):
         return name

--- a/nequip/train/trainer.py
+++ b/nequip/train/trainer.py
@@ -675,7 +675,7 @@ class Trainer:
             or self.metrics_key.lower().startswith(TRAIN)
         ):
             raise RuntimeError(
-                f"metrics key should start with either {VALIDATION} or {TRAIN}"
+                f"metrics_key should start with either {VALIDATION} or {TRAIN}"
             )
 
     def train(self):

--- a/nequip/utils/__init__.py
+++ b/nequip/utils/__init__.py
@@ -1,6 +1,7 @@
 from .auto_init import (
     instantiate_from_cls_name,
     instantiate,
+    get_w_prefix,
 )
 from .savenload import save_file, load_file, atomic_write
 from .config import Config

--- a/nequip/utils/auto_init.py
+++ b/nequip/utils/auto_init.py
@@ -259,20 +259,23 @@ def get_w_prefix(
     else:
         raise ValueError(f"prefix is with a wrong type {type(prefix)}")
 
+    if not isinstance(arg_dicts, list):
+        arg_dicts = [arg_dicts]
+
     # extract all the parameters that has the pattern prefix_variable
     # debug container to record all the variable name transformation
     key_mapping = {}
     for idx, arg_dict in enumerate(arg_dicts[::-1]):
         # fetch paratemeters that directly match the name
         _keys = config.update(arg_dict)
-        key_mapping[f"{idx}"] = {k: k for k in _keys}
+        key_mapping[idx] = {k: k for k in _keys}
         # fetch paratemeters that match prefix + "_" + name
         for idx, prefix_str in enumerate(prefix_list):
             _keys = config.update_w_prefix(
                 arg_dict,
                 prefix=prefix_str,
             )
-            key_mapping[f"{idx}"].update(_keys)
+            key_mapping[idx].update(_keys)
 
     # for logging only, remove the overlapped keys
     num_dicts = len(arg_dicts)
@@ -280,8 +283,8 @@ def get_w_prefix(
         for id_dict in range(num_dicts - 1):
             higher_priority_keys = []
             for id_higher in range(id_dict + 1, num_dicts):
-                higher_priority_keys += list(key_mapping[f"{id_higher}"].keys())
-            key_mapping[f"{id_dict}"] = {
+                higher_priority_keys += list(key_mapping[id_higher].keys())
+            key_mapping[id_dict] = {
                 k: v
                 for k, v in key_mapping[id_dict].items()
                 if k not in higher_priority_keys
@@ -291,7 +294,7 @@ def get_w_prefix(
     logging.debug(f"search for {key} with prefix {prefix}")
     for t in key_mapping:
         for k, v in key_mapping[t].items():
-            string = f" {t:>10.10}_args :  {k:>50s}"
+            string = f" {str(t):>10.10}_args :  {k:>50s}"
             if k != v:
                 string += f" <- {v:>50s}"
             logging.debug(string)

--- a/nequip/utils/auto_init.py
+++ b/nequip/utils/auto_init.py
@@ -89,8 +89,10 @@ def instantiate(
     prefix_list = [builder.__name__] if inspect.isclass(builder) else []
     if isinstance(prefix, str):
         prefix_list += [prefix]
-    else:
+    elif isinstance(prefix, list):
         prefix_list += prefix
+    else:
+        raise ValueError(f"prefix has the wrong type {type(prefix)}")
 
     # detect the input parameters needed from params
     config = Config.from_class(builder, remove_kwargs=remove_kwargs)
@@ -234,3 +236,64 @@ def instantiate(
         ) from e
 
     return instance, final_optional_args
+
+
+def get_w_prefix(
+    key: List[str],
+    *kwargs,
+    arg_dicts: List[dict] = [],
+    prefix: Optional[Union[str, List[str]]] = [],
+):
+    """
+    act as the get function and try to search for the value key from arg_dicts
+    """
+
+    # detect the input parameters needed from params
+    config = Config(config={}, allow_list=[key])
+
+    # sort out all possible prefixes
+    if isinstance(prefix, str):
+        prefix_list = [prefix]
+    elif isinstance(prefix, list):
+        prefix_list = prefix
+    else:
+        raise ValueError(f"prefix is with a wrong type {type(prefix)}")
+
+    # extract all the parameters that has the pattern prefix_variable
+    # debug container to record all the variable name transformation
+    key_mapping = {}
+    for idx, arg_dict in enumerate(arg_dicts[::-1]):
+        # fetch paratemeters that directly match the name
+        _keys = config.update(arg_dict)
+        key_mapping[f"{idx}"] = {k: k for k in _keys}
+        # fetch paratemeters that match prefix + "_" + name
+        for idx, prefix_str in enumerate(prefix_list):
+            _keys = config.update_w_prefix(
+                arg_dict,
+                prefix=prefix_str,
+            )
+            key_mapping[f"{idx}"].update(_keys)
+
+    # for logging only, remove the overlapped keys
+    num_dicts = len(arg_dicts)
+    if num_dicts > 1:
+        for id_dict in range(num_dicts - 1):
+            higher_priority_keys = []
+            for id_higher in range(id_dict + 1, num_dicts):
+                higher_priority_keys += list(key_mapping[f"{id_higher}"].keys())
+            key_mapping[f"{id_dict}"] = {
+                k: v
+                for k, v in key_mapping[id_dict].items()
+                if k not in higher_priority_keys
+            }
+
+    # debug info
+    logging.debug(f"search for {key} with prefix {prefix}")
+    for t in key_mapping:
+        for k, v in key_mapping[t].items():
+            string = f" {t:>10.10}_args :  {k:>50s}"
+            if k != v:
+                string += f" <- {v:>50s}"
+            logging.debug(string)
+
+    return config.get(key, *kwargs)

--- a/tests/integration/test_train.py
+++ b/tests/integration/test_train.py
@@ -77,16 +77,16 @@ class LearningFactorModel(GraphModuleMixin, torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    "conffile,field",
+    "conffile",
     [
-        ("minimal.yaml", AtomicDataDict.FORCE_KEY),
-        ("minimal_eng.yaml", AtomicDataDict.TOTAL_ENERGY_KEY),
+        "minimal.yaml",
+        "minimal_eng.yaml",
     ],
 )
 @pytest.mark.parametrize(
     "builder", [IdentityModel, ConstFactorModel, LearningFactorModel]
 )
-def test_metrics(nequip_dataset, BENCHMARK_ROOT, conffile, field, builder):
+def test_metrics(nequip_dataset, BENCHMARK_ROOT, conffile, builder):
 
     dtype = str(torch.get_default_dtype())[len("torch.") :]
 
@@ -120,15 +120,15 @@ def test_metrics(nequip_dataset, BENCHMARK_ROOT, conffile, field, builder):
         env["PYTHONPATH"] = ":".join(
             [str(path_to_this_file.parent)] + env.get("PYTHONPATH", "").split(":")
         )
-        with open(f"{tmpdir}/screen", "w+") as screen:
-            retcode = subprocess.run(
-                ["nequip-train", "conf.yaml"],
-                cwd=tmpdir,
-                env=env,
-                stdout=screen,
-                stderr=screen,
-            )
-            retcode.check_returncode()
+
+        retcode = subprocess.run(
+            ["nequip-train", "conf.yaml"],
+            cwd=tmpdir,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        retcode.check_returncode()
 
         # == Load metrics ==
         outdir = f"{tmpdir}/{true_config['root']}/{run_name}/"
@@ -195,13 +195,13 @@ def test_metrics(nequip_dataset, BENCHMARK_ROOT, conffile, field, builder):
 
 
 @pytest.mark.parametrize(
-    "conffile,field",
+    "conffile",
     [
-        ("minimal.yaml", AtomicDataDict.FORCE_KEY),
-        ("example.yaml", AtomicDataDict.TOTAL_ENERGY_KEY),
+        "minimal.yaml",
+        "minimal_eng.yaml",
     ],
 )
-def test_requeue(nequip_dataset, BENCHMARK_ROOT, conffile, field):
+def test_requeue(nequip_dataset, BENCHMARK_ROOT, conffile):
 
     builder = IdentityModel
     dtype = str(torch.get_default_dtype())[len("torch.") :]
@@ -240,15 +240,15 @@ def test_requeue(nequip_dataset, BENCHMARK_ROOT, conffile, field):
             env["PYTHONPATH"] = ":".join(
                 [str(path_to_this_file.parent)] + env.get("PYTHONPATH", "").split(":")
             )
-            with open(f"{tmpdir}/screen", "w+") as screen:
-                retcode = subprocess.run(
-                    ["nequip-train", "conf.yaml"],
-                    cwd=tmpdir,
-                    env=env,
-                    stdout=screen,
-                    stderr=screen,
-                )
-                retcode.check_returncode()
+
+            retcode = subprocess.run(
+                ["nequip-train", "conf.yaml"],
+                cwd=tmpdir,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            retcode.check_returncode()
 
             # == Load metrics ==
             dat = np.genfromtxt(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
- Change default `metrics_key` from `loss` to `validation_loss`.
- Allow users to  register new `node_fields`, `graph_fields` and `edge_fields` via yaml interface
- allow `global_rescale` and `per_species_rescale` prefixes to be removed in the yaml file.
- a new `get_w_prefix` method is available to search of variables among dictionary.

## Motivation and Context
The current development version fails to restart due to a conflict on the `metrics_key`.
And it only takes `dataset_node_fields`, but not `node_fields`. 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [x] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [x] I have updated `CHANGELOG.md`.