### PR TITLE
included free_energy property in nequip calculator

### DIFF
--- a/nequip/dynamics/nequip_calculator.py
+++ b/nequip/dynamics/nequip_calculator.py
@@ -10,7 +10,7 @@ import nequip.scripts.deploy
 class NequIPCalculator(Calculator):
     """NequIP ASE Calculator."""
 
-    implemented_properties = ["energy", "forces","stress"]
+    implemented_properties = ["energy", "forces", "stress", "free_energy"]
 
     def __init__(
         self,
@@ -69,6 +69,7 @@ class NequIPCalculator(Calculator):
             # force has units eng / len:
             "forces": forces * (self.energy_units_to_eV / self.length_units_to_A),
         }
+        self.results['free_energy'] = self.results['energy']
         if "stress" in properties:
             stress = out[AtomicDataDict.STRESS_KEY].detach().cpu().numpy()
             stress=stress.reshape(3,3)*(self.energy_units_to_eV/self.length_units_to_A**3)


### PR DESCRIPTION
When performing full geometry optimizations in ASE (using the `ExpCellFilter` wrapper around an `Atoms` instance to include the box vector components as variables in the optimization), it is necessary to include the `free_energy` as an additional implemented property. Its value is simply set equal to the potential energy -- a similar quick fix was used in many of the calculators in ASE recently.