### PR TITLE
version updates for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NequIP is an open-source code for building E(3)-equivariant interatomic potentia
 NequIP requires:
 
 * Python >= 3.6
-* PyTorch >= 1.8
+* PyTorch >= 1.8, <1.10 (PyTorch 1.10 support is in the works on `develop`.)
 
 To install:
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "tqdm",
         "torch>=1.8",
         "torch_geometric==1.7.2",
-        "e3nn>=0.3.3",
+        "e3nn==0.3.5",
         "pyyaml",
         "contextlib2;python_version<'3.7'",  # backport of nullcontext
         "typing_extensions;python_version<'3.8'",


### PR DESCRIPTION
 - note current lack of support for PyTorch 1.10
 - force `main` to use e3nn versions before the 0.4.0 breaking changes