### PR TITLE
handle the irreps for SequentialGraphNetwork.insert

### DIFF
--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -78,6 +78,25 @@ class GraphModuleMixin:
         new_out.update(irreps_out)
         self.irreps_out = new_out
 
+    def add_independent_irreps(self, irreps: Dict[str, Any]):
+        """
+        Insert some independent irreps that need to be exposed to the self.irreps_in and self.irreps_out.
+        The terms that have already appeared in the irreps_in will be removed.
+
+        Args:
+            irreps (dict): maps names of all new fields
+        """
+
+        irreps = {
+            key: irrep for key, irrep in irreps.items() if key not in self.irreps_in
+        }
+        irreps_in = AtomicDataDict._fix_irreps_dict(irreps)
+        irreps_out = AtomicDataDict._fix_irreps_dict(
+            {key: irrep for key, irrep in irreps.items() if key not in self.irreps_out}
+        )
+        self.irreps_in.update(irreps_in)
+        self.irreps_out.update(irreps_out)
+
     def _make_tracing_inputs(self, n):
         # We impliment this to be able to trace graph modules
         out = []
@@ -266,8 +285,28 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
             idx += 1
         names.insert(idx, name)
         modules.insert(idx, module)
+
         self._modules = OrderedDict(zip(names, modules))
-        # TODO: handle irreps
+
+        module_list = list(self._modules.values())
+
+        # sanity check the compatibility
+        if idx > 0:
+            assert AtomicDataDict._irreps_compatible(
+                module_list[idx - 1].irreps_out, module.irreps_in
+            )
+        if len(module_list) > idx:
+            assert AtomicDataDict._irreps_compatible(
+                module_list[idx + 1].irreps_in, module.irreps_out
+            )
+
+        # insert the new irreps_out to the later modules
+        for module_id, next_module in enumerate(module_list[idx + 1 :]):
+            next_module.add_independent_irreps(module.irreps_out)
+
+        # update the final wrapper irreps_out
+        self.irreps_out = dict(module_list[-1].irreps_out)
+
         return
 
     def insert_from_parameters(

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -302,7 +302,7 @@ class SequentialGraphNetwork(GraphModuleMixin, torch.nn.Sequential):
 
         # insert the new irreps_out to the later modules
         for module_id, next_module in enumerate(module_list[idx + 1 :]):
-            next_module.add_independent_irreps(module.irreps_out)
+            next_module._add_independent_irreps(module.irreps_out)
 
         # update the final wrapper irreps_out
         self.irreps_out = dict(module_list[-1].irreps_out)

--- a/nequip/nn/_graph_mixin.py
+++ b/nequip/nn/_graph_mixin.py
@@ -78,7 +78,7 @@ class GraphModuleMixin:
         new_out.update(irreps_out)
         self.irreps_out = new_out
 
-    def add_independent_irreps(self, irreps: Dict[str, Any]):
+    def _add_independent_irreps(self, irreps: Dict[str, Any]):
         """
         Insert some independent irreps that need to be exposed to the self.irreps_in and self.irreps_out.
         The terms that have already appeared in the irreps_in will be removed.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Add a function `add_independent_irreps` to GraphMixin class in order to let new irreps from inserted layers propagate in the SequentialGraphNetwork model.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and has been formatted using `black`.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] `example.yaml` (and other relevant `configs/`) have been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.