### PR TITLE
PyTorch 1.9 no longer works, version 1.10.* is needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NequIP is an open-source code for building E(3)-equivariant interatomic potentia
 NequIP requires:
 
 * Python >= 3.6
-* PyTorch >= 1.8, <=1.10.*. PyTorch can be installed following the [instructions from their documentation](https://pytorch.org/get-started/locally/). Note that neither `torchvision` nor `torchaudio`, included in the default install command, are needed for NequIP. NequIP is also not currently compatible with PyTorch 1.10; PyTorch 1.9 can be specified with `pytorch==1.9` in the install command.
+* PyTorch 1.10.*. PyTorch can be installed following the [instructions from their documentation](https://pytorch.org/get-started/locally/). Note that neither `torchvision` nor `torchaudio`, included in the default install command, are needed for NequIP.
 
 To install:
 


### PR DESCRIPTION

## Description
Minor update to README.md, so it no longer instructs new users to use PyTorch 1.9.X.  The colab example uses 1.10.0.  I failed to get NequIP to work with PyTorch 1.9.0 and 1.9.1 but had no problems with 1.10.0.  Maybe this should be verified by a developer.

## Motivation and Context
A new user following the instructions to the letter will not get a working installation.

**Note:** I make this PR to the main branch, not to the develop branch for that reason.

<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #121 

## How Has This Been Tested?
* Running the code in issue #121 
* Running the test suite with ``pytest nequip/tests/``

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and has been formatted using `black`.
- [X] All new and existing tests passed.
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [X] I have updated the documentation (if relevant).

