### PR TITLE
add mapped keys to include keys for ase dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Most recent change on the bottom.
 ### Fixed
 - Better error in `Dataset.statistics` when field is missing
 - `NequIPCalculator` now outputs energy as scalar rather than `(1, 1)` array
+- `dataset: ase` now treats automatically adds `key_mapping` keys to `include_keys`, which is consistant with the npz dataset
 
 ## [0.5.3] - 2022-02-23
 ### Added

--- a/nequip/data/AtomicData.py
+++ b/nequip/data/AtomicData.py
@@ -369,7 +369,10 @@ class AtomicData(Data):
             + list(kwargs.keys())
         )
         # the keys that are duplicated in kwargs are removed from the include_keys
-        include_keys = list(set(include_keys + ase_all_properties) - default_args)
+        include_keys = list(
+            set(include_keys + ase_all_properties + list(key_mapping.keys()))
+            - default_args
+        )
 
         km = {
             "forces": AtomicDataDict.FORCE_KEY,

--- a/nequip/train/trainer.py
+++ b/nequip/train/trainer.py
@@ -436,7 +436,7 @@ class Trainer:
             for key in self.train_on_keys:
                 if key not in self.model.irreps_out:
                     raise RuntimeError(
-                        "Loss function include fields that are not predicted by the model"
+                        f"Loss function include fields {key} that are not predicted by the model {self.model.irreps_out}"
                     )
 
     @property


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
In the NPZ dataset, the keys in `key_mapping` are automatically added to the include_keys. But it is not the case in the case dataset. 

## Motivation and Context
The from_ase function is slightly modified to make the ase dataset and npz dataset perform consistently.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

