### PR TITLE
make dataset an optional argument for rescaling builder

### DIFF
--- a/nequip/model/_scaling.py
+++ b/nequip/model/_scaling.py
@@ -12,7 +12,10 @@ RESCALE_THRESHOLD = 1e-6
 
 
 def RescaleEnergyEtc(
-    model: GraphModuleMixin, config, initialize: bool, dataset: Optional[AtomicDataset] = None
+    model: GraphModuleMixin,
+    config,
+    initialize: bool,
+    dataset: Optional[AtomicDataset] = None,
 ):
     return GlobalRescale(
         model=model,

--- a/nequip/model/_scaling.py
+++ b/nequip/model/_scaling.py
@@ -12,7 +12,7 @@ RESCALE_THRESHOLD = 1e-6
 
 
 def RescaleEnergyEtc(
-    model: GraphModuleMixin, config, dataset: AtomicDataset, initialize: bool
+    model: GraphModuleMixin, config, initialize: bool, dataset: Optional[AtomicDataset] = None
 ):
     return GlobalRescale(
         model=model,
@@ -34,7 +34,6 @@ def RescaleEnergyEtc(
 def GlobalRescale(
     model: GraphModuleMixin,
     config,
-    dataset: AtomicDataset,
     initialize: bool,
     module_prefix: str,
     default_scale: Union[str, float, list],
@@ -43,6 +42,7 @@ def GlobalRescale(
     default_shift_keys: list,
     default_related_scale_keys: list,
     default_related_shift_keys: list,
+    dataset: Optional[AtomicDataset] = None,
 ):
     """Add global rescaling for energy(-based quantities).
 
@@ -75,11 +75,12 @@ def GlobalRescale(
                 raise ValueError(f"Invalid global scale `{value}`")
 
         # = Compute shifts and scales =
-        computed_stats = _compute_stats(
-            str_names=str_names,
-            dataset=dataset,
-            stride=config.dataset_statistics_stride,
-        )
+        if len(str_names) > 0:
+            computed_stats = _compute_stats(
+                str_names=str_names,
+                dataset=dataset,
+                stride=config.dataset_statistics_stride,
+            )
 
         if isinstance(global_scale, str):
             s = global_scale
@@ -129,8 +130,8 @@ def GlobalRescale(
 def PerSpeciesRescale(
     model: GraphModuleMixin,
     config,
-    dataset: AtomicDataset,
     initialize: bool,
+    dataset: Optional[AtomicDataset] = None,
 ):
     """Add global rescaling for energy(-based quantities).
 
@@ -199,12 +200,13 @@ def PerSpeciesRescale(
                 ], "Requested to set either the shifts or scales of the per_species_rescale using dataset values, but chose to provide the other in non-dataset units. Please give the explictly specified shifts/scales in dataset units and set per_species_rescale_arguments_in_dataset_units"
 
         # = Compute shifts and scales =
-        computed_stats = _compute_stats(
-            str_names=str_names,
-            dataset=dataset,
-            stride=config.dataset_statistics_stride,
-            kwargs=config.get(module_prefix + "_kwargs", {}),
-        )
+        if len(str_names) > 0:
+            computed_stats = _compute_stats(
+                str_names=str_names,
+                dataset=dataset,
+                stride=config.dataset_statistics_stride,
+                kwargs=config.get(module_prefix + "_kwargs", {}),
+            )
 
         if isinstance(scales, str):
             s = scales


### PR DESCRIPTION
## Description
Make dataset an optional argument for rescaling builders. so one can define the model from python api without errors like below
```python
 from nequip.utils import Config
 from nequip.model import model_from_config
 from nequip.scripts.train import default_config

 config = {}
 config.update(default_config)
 config.update(dict(
     l_max=2,
     parity=True,
     num_features=64,
     avg_num_neighbors=None,
     chemical_symbols = ["H", "C", "O"],
     num_basis=8,
     r_max=4.0,
     per_species_rescale_scales_trainable = True,
     per_species_rescale_shifts_trainable = False,
     global_rescale_scale = 1.0,
     per_species_rescale_shifts = 0.0,
     per_species_rescale_scales = 1.0,
 ))
 final_model = model_from_config(
         config=Config.from_dict(config), initialize=True, dataset=None,
 )
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

