### PR TITLE
Para stress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Most recent change on the bottom.
 
 ## [Unreleased] - 0.5.6
 ### Added
+- `ParaStressForceOutput` Support for atom virial and virial parallism in Lammps.
 - sklearn dependency removed
 - `nequip-benchmark` and `nequip-train` report number of weights and number of trainable weights
 - `nequip-benchmark --no-compile` and `--verbose` and `--memory-summary`

--- a/nequip/data/AtomicData.py
+++ b/nequip/data/AtomicData.py
@@ -41,6 +41,7 @@ _DEFAULT_NODE_FIELDS: Set[str] = {
     AtomicDataDict.FORCE_KEY,
     AtomicDataDict.PER_ATOM_ENERGY_KEY,
     AtomicDataDict.BATCH_KEY,
+    AtomicDataDict.ATOM_VIRIAL_KEY,
 }
 _DEFAULT_EDGE_FIELDS: Set[str] = {
     AtomicDataDict.EDGE_CELL_SHIFT_KEY,

--- a/nequip/data/_keys.py
+++ b/nequip/data/_keys.py
@@ -55,6 +55,7 @@ FORCE_KEY: Final[str] = "forces"
 PARTIAL_FORCE_KEY: Final[str] = "partial_forces"
 STRESS_KEY: Final[str] = "stress"
 VIRIAL_KEY: Final[str] = "virial"
+ATOM_VIRIAL_KEY: Final[str] = "atom_virial"
 
 ALL_ENERGY_KEYS: Final[List[str]] = [
     PER_ATOM_ENERGY_KEY,
@@ -63,6 +64,7 @@ ALL_ENERGY_KEYS: Final[List[str]] = [
     PARTIAL_FORCE_KEY,
     STRESS_KEY,
     VIRIAL_KEY,
+    ATOM_VIRIAL_KEY,
 ]
 
 BATCH_KEY: Final[str] = "batch"

--- a/nequip/model/__init__.py
+++ b/nequip/model/__init__.py
@@ -1,5 +1,5 @@
 from ._eng import EnergyModel, SimpleIrrepsConfig
-from ._grads import ForceOutput, PartialForceOutput, StressForceOutput
+from ._grads import ForceOutput, PartialForceOutput, StressForceOutput, ParaStressForceOutput
 from ._scaling import RescaleEnergyEtc, PerSpeciesRescale
 from ._weight_init import (
     uniform_initialize_FCs,
@@ -17,6 +17,7 @@ __all__ = [
     ForceOutput,
     PartialForceOutput,
     StressForceOutput,
+    ParaStressForceOutput,
     RescaleEnergyEtc,
     PerSpeciesRescale,
     uniform_initialize_FCs,

--- a/nequip/model/__init__.py
+++ b/nequip/model/__init__.py
@@ -1,5 +1,10 @@
 from ._eng import EnergyModel, SimpleIrrepsConfig
-from ._grads import ForceOutput, PartialForceOutput, StressForceOutput, ParaStressForceOutput
+from ._grads import (
+    ForceOutput,
+    PartialForceOutput,
+    StressForceOutput,
+    ParaStressForceOutput,
+)
 from ._scaling import RescaleEnergyEtc, PerSpeciesRescale
 from ._weight_init import (
     uniform_initialize_FCs,

--- a/nequip/model/_grads.py
+++ b/nequip/model/_grads.py
@@ -58,6 +58,7 @@ def StressForceOutput(model: GraphModuleMixin) -> GradientOutput:
         raise ValueError("This model already has force or stress outputs.")
     return StressOutputModule(func=model)
 
+
 def ParaStressForceOutput(model: GraphModuleMixin) -> GradientOutput:
     r"""Add forces and stresses to a model that predicts energy.
 

--- a/nequip/model/_grads.py
+++ b/nequip/model/_grads.py
@@ -1,6 +1,7 @@
 from nequip.nn import GraphModuleMixin, GradientOutput
 from nequip.nn import PartialForceOutput as PartialForceOutputModule
 from nequip.nn import StressOutput as StressOutputModule
+from nequip.nn import ParaStressOutput as ParaStressOutputModule
 from nequip.data import AtomicDataDict
 
 
@@ -56,3 +57,19 @@ def StressForceOutput(model: GraphModuleMixin) -> GradientOutput:
     ):
         raise ValueError("This model already has force or stress outputs.")
     return StressOutputModule(func=model)
+
+def ParaStressForceOutput(model: GraphModuleMixin) -> GradientOutput:
+    r"""Add forces and stresses to a model that predicts energy.
+
+    Args:
+        model: the model to wrap. Must have ``AtomicDataDict.TOTAL_ENERGY_KEY`` as an output.
+
+    Returns:
+        A ``StressOutput`` wrapping ``model``.
+    """
+    if (
+        AtomicDataDict.FORCE_KEY in model.irreps_out
+        or AtomicDataDict.STRESS_KEY in model.irreps_out
+    ):
+        raise ValueError("This model already has force or stress outputs.")
+    return ParaStressOutputModule(func=model)

--- a/nequip/nn/__init__.py
+++ b/nequip/nn/__init__.py
@@ -6,7 +6,12 @@ from ._atomwise import (  # noqa: F401
     PerSpeciesScaleShift,
 )  # noqa: F401
 from ._interaction_block import InteractionBlock  # noqa: F401
-from ._grad_output import GradientOutput, PartialForceOutput, StressOutput, ParaStressOutput  # noqa: F401
+from ._grad_output import (
+    GradientOutput,
+    PartialForceOutput,
+    StressOutput,
+    ParaStressOutput,
+)  # noqa: F401
 from ._rescale import RescaleOutput  # noqa: F401
 from ._convnetlayer import ConvNetLayer  # noqa: F401
 from ._util import SaveForOutput  # noqa: F401

--- a/nequip/nn/__init__.py
+++ b/nequip/nn/__init__.py
@@ -6,7 +6,7 @@ from ._atomwise import (  # noqa: F401
     PerSpeciesScaleShift,
 )  # noqa: F401
 from ._interaction_block import InteractionBlock  # noqa: F401
-from ._grad_output import GradientOutput, PartialForceOutput, StressOutput  # noqa: F401
+from ._grad_output import GradientOutput, PartialForceOutput, StressOutput, ParaStressOutput  # noqa: F401
 from ._rescale import RescaleOutput  # noqa: F401
 from ._convnetlayer import ConvNetLayer  # noqa: F401
 from ._util import SaveForOutput  # noqa: F401

--- a/nequip/nn/_grad_output.py
+++ b/nequip/nn/_grad_output.py
@@ -403,7 +403,7 @@ class ParaStressOutput(GraphModuleMixin, torch.nn.Module):
 
         did_pos_req_grad: bool = pos.requires_grad
         pos.requires_grad_(True)
-        data[AtomicDataDict.POSITIONS_KEY] = pos 
+        data[AtomicDataDict.POSITIONS_KEY] = pos
         data = AtomicDataDict.with_edge_vectors(data, with_lengths=False)
         data[AtomicDataDict.EDGE_VECTORS_KEY].requires_grad_(True)
 
@@ -423,13 +423,19 @@ class ParaStressOutput(GraphModuleMixin, torch.nn.Module):
             assert False, "failed to compute forces autograd"
         forces = torch.neg(forces)
         data[AtomicDataDict.FORCE_KEY] = forces
-        
+
         # Store virial
         vector_force = grads[1]
-        edge_virial_1 = torch.einsum("zi,zj->zij", vector_force, data[AtomicDataDict.EDGE_VECTORS_KEY])
-        edge_virial_2 = torch.einsum("zi,zj->zji", vector_force, data[AtomicDataDict.EDGE_VECTORS_KEY])
-        edge_virial = (edge_virial_1 + edge_virial_2)/2
-        atom_virial = scatter(edge_virial, data[AtomicDataDict.EDGE_INDEX_KEY][0], dim=0, reduce="sum")
+        edge_virial_1 = torch.einsum(
+            "zi,zj->zij", vector_force, data[AtomicDataDict.EDGE_VECTORS_KEY]
+        )
+        edge_virial_2 = torch.einsum(
+            "zi,zj->zji", vector_force, data[AtomicDataDict.EDGE_VECTORS_KEY]
+        )
+        edge_virial = (edge_virial_1 + edge_virial_2) / 2
+        atom_virial = scatter(
+            edge_virial, data[AtomicDataDict.EDGE_INDEX_KEY][0], dim=0, reduce="sum"
+        )
         virial = scatter(atom_virial, batch, dim=0, reduce="sum")
 
         # virial = grads[1]

--- a/nequip/utils/test.py
+++ b/nequip/utils/test.py
@@ -194,7 +194,7 @@ def assert_AtomicData_equivariant(
             # must be this to actually rotate it
             irps[AtomicDataDict.CELL_KEY] = "3x1o"
 
-    stress_keys = (AtomicDataDict.STRESS_KEY, AtomicDataDict.VIRIAL_KEY)
+    stress_keys = (AtomicDataDict.STRESS_KEY, AtomicDataDict.VIRIAL_KEY, AtomicDataDict.ATOM_VIRIAL_KEY)
     for k in stress_keys:
         irreps_in.pop(k, None)
     if any(k in irreps_out for k in stress_keys):

--- a/nequip/utils/test.py
+++ b/nequip/utils/test.py
@@ -194,7 +194,11 @@ def assert_AtomicData_equivariant(
             # must be this to actually rotate it
             irps[AtomicDataDict.CELL_KEY] = "3x1o"
 
-    stress_keys = (AtomicDataDict.STRESS_KEY, AtomicDataDict.VIRIAL_KEY, AtomicDataDict.ATOM_VIRIAL_KEY)
+    stress_keys = (
+        AtomicDataDict.STRESS_KEY,
+        AtomicDataDict.VIRIAL_KEY,
+        AtomicDataDict.ATOM_VIRIAL_KEY,
+    )
     for k in stress_keys:
         irreps_in.pop(k, None)
     if any(k in irreps_out for k in stress_keys):

--- a/nequip/utils/unittests/conftest.py
+++ b/nequip/utils/unittests/conftest.py
@@ -138,7 +138,7 @@ def bulks() -> List[Atoms]:
     atoms_list = []
     for i in range(8):
         atoms = bulk("C")
-        atoms = make_supercell(atoms,[[2,0,0],[0,2,0],[0,0,2]])
+        atoms = make_supercell(atoms, [[2, 0, 0], [0, 2, 0], [0, 0, 2]])
         atoms.rattle()
         atoms.calc = SinglePointCalculator(
             energy=np.random.random(),
@@ -165,10 +165,10 @@ def nequip_bulk_dataset(bulks, temp_data, float_tolerance):
         )
         yield a
 
+
 @pytest.fixture(scope="session")
 def atomic_bulk_batch(nequip_bulk_dataset):
     return Batch.from_data_list([nequip_bulk_dataset[0], nequip_bulk_dataset[1]])
-
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/model/test_nequip_model.py
+++ b/tests/unit/model/test_nequip_model.py
@@ -152,6 +152,6 @@ class TestNequIPModel(BaseEnergyModelTests):
         output_og = model_og(AtomicData.to_AtomicDataDict(data))
         output_para = model_para(AtomicData.to_AtomicDataDict(data))
         
-        assert torch.allclose(output_og[AtomicDataDict.STRESS_KEY], output_para[AtomicDataDict.STRESS_KEY], atol=5e-6)
-        assert torch.allclose(output_og[AtomicDataDict.VIRIAL_KEY], output_para[AtomicDataDict.VIRIAL_KEY], atol=5e-6)
+        assert torch.allclose(output_og[AtomicDataDict.STRESS_KEY], output_para[AtomicDataDict.STRESS_KEY], atol=1e-6)
+        assert torch.allclose(output_og[AtomicDataDict.VIRIAL_KEY], output_para[AtomicDataDict.VIRIAL_KEY], atol=1e-5) # Little big here caused by the summation over edges.
 

--- a/tests/unit/model/test_nequip_model.py
+++ b/tests/unit/model/test_nequip_model.py
@@ -138,20 +138,27 @@ class TestNequIPModel(BaseEnergyModelTests):
         config_og["model_builders"] = ["EnergyModel", "StressForceOutput"]
         model_og = model_from_config(config=config_og, initialize=True)
         nn_state = model_og.state_dict()
-        
+
         config_para = minimal_config2.copy()
         config_para["model_builders"] = ["EnergyModel", "ParaStressForceOutput"]
         model_para = model_from_config(config=config_para, initialize=True)
-        
-        model_para.load_state_dict(nn_state, strict = True)
-        
+
+        model_para.load_state_dict(nn_state, strict=True)
+
         model_og.to(device)
         model_para.to(device)
         data = atomic_bulk_batch.to(device)
-        
+
         output_og = model_og(AtomicData.to_AtomicDataDict(data))
         output_para = model_para(AtomicData.to_AtomicDataDict(data))
-        
-        assert torch.allclose(output_og[AtomicDataDict.STRESS_KEY], output_para[AtomicDataDict.STRESS_KEY], atol=1e-6)
-        assert torch.allclose(output_og[AtomicDataDict.VIRIAL_KEY], output_para[AtomicDataDict.VIRIAL_KEY], atol=1e-5) # Little big here caused by the summation over edges.
 
+        assert torch.allclose(
+            output_og[AtomicDataDict.STRESS_KEY],
+            output_para[AtomicDataDict.STRESS_KEY],
+            atol=1e-6,
+        )
+        assert torch.allclose(
+            output_og[AtomicDataDict.VIRIAL_KEY],
+            output_para[AtomicDataDict.VIRIAL_KEY],
+            atol=1e-5,
+        )  # Little big here caused by the summation over edges.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
`ParaStressForceOutput` Support for atom virial and virial parallelism in Lammps.
## Description
<!-- Describe your changes in detail. -->
Another algorithm implementation for stress calculation can calculate atom virial and should help with parallelism of Allegro in Lammps.
PBC systems are used for tests.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: [pari_allegro#9](https://github.com/mir-group/pair_allegro/issues/9)
Enable Allegro NPT simulations.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Stress and virial results of `ParaStressForceOutput` and `StressForceOutput` are consistent.
Tests are carried on a PBC system with cell.
Just replace `StressForceOutput` with `ParaStressForceOutput` :)
See test_stress in [nequip](https://github.com/Hongyu-yu/nequip/tree/para_stress)/[tests](https://github.com/Hongyu-yu/nequip/tree/para_stress/tests)/[unit](https://github.com/Hongyu-yu/nequip/tree/para_stress/tests/unit)/[model](https://github.com/Hongyu-yu/nequip/tree/para_stress/tests/unit/model)/test_nequip_model.py.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [x] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

