### PR TITLE
Allow calculation of isolated atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Most recent change on the bottom.
 - `nequip-benchmark` now only uses `--n-data` frames to build the model
 - [Breaking] By default models now use `StressForceOutput`, not `ForceOutput`
 - Added `edge_energy` to `ALL_ENERGY_KEYS` subjecting it to global rescale
+- Allow calculation of atomic and well-separated dimer energies
 
 ### Fixed
 - Work with `wandb>=0.13.8`

--- a/examples/plot_dimers.py
+++ b/examples/plot_dimers.py
@@ -41,7 +41,7 @@ potential = {}
 N_sample = args.n_samples
 N_combs = len(list(itertools.combinations_with_replacement(range(num_types), 2)))
 r = torch.zeros(N_sample * N_combs, 2, 3, device=args.device)
-rs_one = torch.linspace(args.r_min, model_r_max, 500, device=args.device)
+rs_one = torch.linspace(args.r_min, model_r_max, N_sample, device=args.device)
 rs = rs_one.repeat([N_combs])
 assert rs.shape == (N_combs * N_sample,)
 r[:, 1, 0] += rs  # offset second atom along x axis
@@ -86,7 +86,10 @@ fig, axs = plt.subplots(
 for i, (type1, type2) in enumerate(
     itertools.combinations_with_replacement(range(num_types), 2)
 ):
-    ax = axs[i]
+    try:
+        ax = axs[i]
+    except:
+        ax = axs
     ax.set_ylabel(f"{type_names[type1]}-{type_names[type2]}")
     ax.plot(rs_one, energies[i])
 

--- a/nequip/nn/_atomwise.py
+++ b/nequip/nn/_atomwise.py
@@ -218,6 +218,8 @@ class PerSpeciesScaleShift(GraphModuleMixin, torch.nn.Module):
             return data
 
         species_idx = data[AtomicDataDict.ATOM_TYPE_KEY].squeeze(-1)
+        if len(species_idx.shape) == 0:
+            species_idx = data[AtomicDataDict.ATOM_TYPE_KEY]
         in_field = data[self.field]
         assert len(in_field) == len(
             species_idx

--- a/nequip/nn/_grad_output.py
+++ b/nequip/nn/_grad_output.py
@@ -20,6 +20,7 @@ class GradientOutput(GraphModuleMixin, torch.nn.Module):
         out_field: the field in which to return the computed gradients. Defaults to ``f"d({of})/d({wrt})"`` for each field in ``wrt``.
         sign: either 1 or -1; the returned gradient is multiplied by this.
     """
+
     sign: float
     _negate: bool
     skip: bool
@@ -103,18 +104,19 @@ class GradientOutput(GraphModuleMixin, torch.nn.Module):
             for out, grad in zip(self.out_field, grads):
                 if grad is None:
                     # From the docs: "If an output doesn’t require_grad, then the gradient can be None"
-                    raise RuntimeError("Something is wrong, gradient couldn't be computed")
-                
+                    raise RuntimeError(
+                        "Something is wrong, gradient couldn't be computed"
+                    )
+
                 if self._negate:
                     grad = torch.neg(grad)
                 data[out] = grad
         else:
-            for out,tens in zip(self.out_field,wrt_tensors):
-                data[out] = torch.zeros( tens.shape, dtype=tens.dtype,
-                                         device=tens.device )
+            for out, tens in zip(self.out_field, wrt_tensors):
+                data[out] = torch.zeros(
+                    tens.shape, dtype=tens.dtype, device=tens.device
+                )
 
-
-                
         # unset requires_grad_
         for req_grad, k in zip(old_requires_grad, self.wrt):
             data[k].requires_grad_(req_grad)
@@ -131,6 +133,7 @@ class PartialForceOutput(GraphModuleMixin, torch.nn.Module):
         vectorize: the vectorize option to ``torch.autograd.functional.jacobian``,
             false by default since it doesn't work well.
     """
+
     vectorize: bool
 
     def __init__(
@@ -195,6 +198,7 @@ class StressOutput(GraphModuleMixin, torch.nn.Module):
         func: the energy model to wrap
         do_forces: whether to compute forces as well
     """
+
     do_forces: bool
 
     def __init__(


### PR DESCRIPTION
## Description

1. plot_dimers.py: The --n-samples was not being respected when calculating the linear spacing. Furthermore, if the model contained a single atom type, then matplotlib returns a scalar axes variable rather than a list.
2. _atomwise.py: Prevent assert failure when the system consists of a single atom
3. _grad_output.py: If a system consists of a single atom, then pytorch will complain that there are no gradients to calculate. The proposed "fix" is to check if all of the configurations consist of 1 atom; if so, then don't call autograd - instead return zeros.


## Motivation and Context
Previous version of nequip could not calculate the energy of an isolate atom. One often wants to create loss functions that fit relative energies (not just total energies). If an isolated atom cannot be calculated, then it prevents supermolecular calculation of molecule-atomic ion interactions, for example.  A discussion of this issue, and the calculation of well-separated dimers, can be found on the allegro github project: https://github.com/mir-group/allegro/discussions/82


## How Has This Been Tested?
I followed the nequip/allegro tutorial to generate si-deployed.pth. I then created a python script that reads the model file and an ase xyz file. The model is used to calculate the energy and forces. The energy of a well-separated dimer is verified to be twice the energy of the monomer.

Test environment
- Linux 5.4.14-100.fc30.x86_64
- Python 3.9.12
- pytest-8.2.0
- pluggy-1.5.0
`pytest tests/unit/` log [attached as unit_test.log](https://github.com/mir-group/nequip/files/15194186/unit_test.log)
`pytest tests/` log [attached as test.log](https://github.com/mir-group/nequip/files/15200066/test.log)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] My code follows the code style of this project and has been formatted using `black`.
- [x] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] The option documentation (`docs/options`) has been updated with new or changed options.
- [x] I have updated `CHANGELOG.md`.
- [x] I have updated the documentation (if relevant).

