### PR TITLE
Fixed gather method to work with distributed training in metrics.py and loss.py

### DIFF
--- a/nequip/train/loss.py
+++ b/nequip/train/loss.py
@@ -208,7 +208,11 @@ class LossStat:
                     rs_n = rs_n.to(self.loss_stat[k]._n.device)
 
                     # Accumulate the state by updating _state and _n
-                    self.loss_stat[k]._state = (self.loss_stat[k]._state * self.loss_stat[k]._n + rs_state * rs_n) / (self.loss_stat[k]._n + rs_n)
+                    self.loss_stat[k]._state = (
+                        self.loss_stat[k]._state * self.loss_stat[k]._n + rs_state * rs_n
+                    ) / (self.loss_stat[k]._n + rs_n)
                     self.loss_stat[k]._n += rs_n
                     # Ensure no division by zero issues
-                    self.loss_stat[k]._state = torch.nan_to_num_(self.loss_stat[k]._state, nan=0.0)
+                    self.loss_stat[k]._state = torch.nan_to_num_(
+                        self.loss_stat[k]._state, nan=0.0
+                    )

--- a/nequip/train/metrics.py
+++ b/nequip/train/metrics.py
@@ -289,8 +289,12 @@ class Metrics:
                         rs_n = rs_n.to(self.running_stats[k1][k2]._n.device)
 
                         # Accumulate the state by updating _state and _n
-                        self.running_stats[k1][k2]._state = (self.running_stats[k1][k2]._state * self.running_stats[k1][k2]._n + rs_state * rs_n) / (self.running_stats[k1][k2]._n + rs_n)
+                        self.running_stats[k1][k2]._state = (
+                            self.running_stats[k1][k2]._state * self.running_stats[k1][k2]._n + rs_state * rs_n
+                        ) / (self.running_stats[k1][k2]._n + rs_n)
                         self.running_stats[k1][k2]._n += rs_n
                         # Ensure no division by zero issues
-                        self.running_stats[k1][k2]._state = torch.nan_to_num_(self.running_stats[k1][k2]._state, nan=0.0)
+                        self.running_stats[k1][k2]._state = torch.nan_to_num_(
+                            self.running_stats[k1][k2]._state, nan=0.0
+                        )
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
In the DDP branch, the gather method uses a .get_state() method that does not exist in the torch_runstats package. I implemented a simple work around to directly access the state of the running statistics (_state) and the number of samples (_n). 

In the metrics.py version of gather, I also explicitly made sure the tensors are on the same device prior to accumulating the state. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #449 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

I tested my changes by comparing the output metrics from minimal.yaml and minimal_distributed.yaml. 
[aspirin_pr_test.txt](https://github.com/user-attachments/files/16242535/aspirin_pr_test.txt)
[distributed_aspirin_pr_test.txt](https://github.com/user-attachments/files/16242536/distributed_aspirin_pr_test.txt)

Training time with 2 GPUs (Quadro RTX6000) was 248 seconds with 
[minimal_distributed.txt](https://github.com/user-attachments/files/16242613/minimal_distributed.txt)
 :
``` [bash]
  Train      #    Epoch      wal       LR       loss_f         loss        f_mae       f_rmse
! Train              50  248.091     0.01      0.00573      0.00573         1.76          2.4
! Validation         50  248.091     0.01      0.00808      0.00808         2.01         2.85
Wall time: 248.0915699005127
! Best model       50    0.008
! Stop training: max epochs
Wall time: 248.14249654859304
Cumulative wall time: 248.14249654859304
```
Training time with 1 GPU (Quadro RTX6000) was 566 seconds with 
[minimal.txt](https://github.com/user-attachments/files/16242608/minimal.txt)
:
```[bash]
  Train      #    Epoch      wal       LR       loss_f         loss        f_mae       f_rmse
! Train              50  566.047     0.01      0.00684      0.00684         1.95         2.62
! Validation         50  566.047     0.01      0.00963      0.00963         2.23         3.11
Wall time: 566.0472663491964
! Stop training: max epochs
Wall time: 566.0749344825745
Cumulative wall time: 566.0749344825745
```
I tried another training attempt with 1 GPU 
[aspirin_pr_test_t2.txt](https://github.com/user-attachments/files/16242684/aspirin_pr_test_t2.txt)
:
```[bash]
  Train      #    Epoch      wal       LR       loss_f         loss        f_mae       f_rmse
! Train              50  461.492     0.01      0.00684      0.00684         1.95         2.62
! Validation         50  461.492     0.01      0.00963      0.00963         2.23         3.11
Wall time: 461.4917606860399
! Stop training: max epochs
Wall time: 461.5175565779209
Cumulative wall time: 461.5175565779209
```

Using the state-run runstats branch  
[minimal_distributed_fixed_runstats.txt](https://github.com/user-attachments/files/16254387/minimal_distributed_fixed_runstats.txt)
: 
```[bash]
  Train      #    Epoch      wal       LR       loss_f         loss        f_mae       f_rmse
! Train              50  258.864     0.01      0.00573      0.00573         1.76          2.4
! Validation         50  258.864     0.01      0.00808      0.00808         2.01         2.85
Wall time: 258.8642472475767
! Best model       50    0.008
! Stop training: max epochs
Wall time: 258.9035141095519
Cumulative wall time: 258.9035141095519
```

The configs were setup such that the distributed_batch_size / world_size = batch_size. Not sure what happened between the first and second single gpu test, but perhaps I should repeat the trainings a few times to compare the loss and wall times. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

