### PR TITLE
add missing torch.distributed import

### DIFF
--- a/nequip/train/trainer_wandb.py
+++ b/nequip/train/trainer_wandb.py
@@ -1,6 +1,7 @@
 import wandb
 
 from .trainer import Trainer
+import torch.distributed as dist
 
 
 class TrainerWandB(Trainer):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Add import of torch.distributed in trainer_wandb.py

## Motivation and Context
The import is missing and breaks nequip-train when wandb is enabled.

## How Has This Been Tested?
The change works for my training with DDP and wandb enabled.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

