### PR TITLE
Bug: fix scripts/train.py to account for test/val/pred only

### DIFF
--- a/nequip/scripts/train.py
+++ b/nequip/scripts/train.py
@@ -53,7 +53,7 @@ def main(config: DictConfig) -> None:
 
     # ensure only single train at most, to protect restart and checkpointing logic later
     assert (
-        sum([run_type == "train" for run_type in runs]) == 1
+        sum([run_type == "train" for run_type in runs]) <= 1
     ), "only a single `train` instance can be present in `run`"
 
     # ensure that the relevant metrics are present


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Small typo in scripts for training that would limit the usage of the script to contain the `train` step. This is now fixed, so that the `test` or other types of run can be performed as well as single steps.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

Tested locally, but no unit test for this ATM. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The option documentation (`docs/options`) has been updated with new or changed options.
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).

