### PR TITLE
Bound CI torch version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        torch-version: [1.13.1, "2.*"]
+        torch-version: [1.13.1, 2.5]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_develop.yml
+++ b/.github/workflows/tests_develop.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        torch-version: ["2.*"]
+        torch-version: [2.5]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GH actions for https://github.com/mir-group/nequip/pull/465 seems to be failing, testing if adding a torch version bound helps.