### PR TITLE
feature/L3_and_L4_loss: added the mean cubic and mean quartic errors

### DIFF
--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -62,6 +62,12 @@ Error Metrics
 .. autoclass:: nequip.train.MeanAbsoluteError
    :members:
 
+.. autoclass:: nequip.train.MeanCubicError
+   :members:
+
+.. autoclass:: nequip.train.MeanQuarticError
+   :members:
+
 .. autoclass:: nequip.train.HuberLoss
    :members:
 

--- a/nequip/train/metrics.py
+++ b/nequip/train/metrics.py
@@ -42,6 +42,34 @@ class RootMeanSquaredError(MeanSquaredError):
         return "rmse"
 
 
+class MeanCubicError(_MeanX):
+    """Mean cubic error (L3 norm)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(modifier=lambda x: torch.pow(torch.abs(x), 3), **kwargs)
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        """"""
+        super().update(preds - target)
+
+    def __str__(self) -> str:
+        return "mce"
+
+
+class MeanQuarticError(_MeanX):
+    """Mean quartic error (L4 norm)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(modifier=lambda x: torch.pow(x, 4), **kwargs)
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        """"""
+        super().update(preds - target)
+
+    def __str__(self) -> str:
+        return "mqe"
+
+
 class HuberLoss(_MeanX):
     """Huber loss (see `torch.nn.HuberLoss <https://pytorch.org/docs/stable/generated/torch.nn.HuberLoss.html>`_)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
I've just added L3 and L4 to the nequip/train/metrics.py following the exact format of MSE. 

## Motivation and Context
For systems where large forces are more important, L3 and L4 metrics could prioritize getting those forces correct. 

## How Has This Been Tested?
I didn't test this, but I've copied and pasted the MSE code with the exact same form.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read ["Contributing to NequIP"](../docs/dev/contributing.md).
- [X] My code follows the code style of this project and has been formatted using `black`.
- [X] All new and existing tests passed, including on GPU (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [ ] I have updated `CHANGELOG.md`.
- [X] I have updated the documentation (if relevant).
