### PR TITLE
Replaced OEQ forward call with opaque variant

### DIFF
--- a/nequip/nn/_tp_scatter_oeq.py
+++ b/nequip/nn/_tp_scatter_oeq.py
@@ -41,5 +41,7 @@ class OpenEquivarianceTensorProductScatter(TensorProductScatter):
         self.tp_conv = TensorProductConv(tpp, torch_op=True, deterministic=False)
 
     def forward(self, x, edge_attr, edge_weight, edge_dst, edge_src):
-        # NB: Opaque forward call disables C++ export at the moment 
-        return self.tp_conv.forward_opaque(x, edge_attr, edge_weight, edge_dst, edge_src)
+        # NB: Opaque forward call disables C++ export at the moment
+        return self.tp_conv.forward_opaque(
+            x, edge_attr, edge_weight, edge_dst, edge_src
+        )

--- a/nequip/nn/_tp_scatter_oeq.py
+++ b/nequip/nn/_tp_scatter_oeq.py
@@ -41,4 +41,5 @@ class OpenEquivarianceTensorProductScatter(TensorProductScatter):
         self.tp_conv = TensorProductConv(tpp, torch_op=True, deterministic=False)
 
     def forward(self, x, edge_attr, edge_weight, edge_dst, edge_src):
-        return self.tp_conv(x, edge_attr, edge_weight, edge_dst, edge_src)
+        # NB: Opaque forward call disables C++ export at the moment 
+        return self.tp_conv.forward_opaque(x, edge_attr, edge_weight, edge_dst, edge_src)


### PR DESCRIPTION
## Description
Prevents torch from tracing through oeq operations.

## Motivation and Context
Downside: disables C++ export for the moment (PT2.8 should fix). 
Upside: enables composition with export + compile during training.

## How Has This Been Tested?
Standard oeq tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read ["Contributing to NequIP"](../docs/dev/contributing.md).
- [x] My code follows the code style of this project and has been formatted using `black`.
- [x] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] I have updated `CHANGELOG.md`.
- [x] I have updated the documentation (if relevant).
