### PR TITLE
Allegro-pol fix

### DIFF
--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -29,6 +29,8 @@ class SimpleLoss:
         
         # This is the hotfix for the issue that the loss function is not found 
         # > NameError: <allegro_pol.pol_loss.FoldedPolLoss object at 0x7fda9286fd90> type is not found in torch.nn module
+        func_name = func_name.lstrip("<")
+        func_name = func_name.rstrip(">")
         module_trees = func_name.split(".")
         parent_module = ".".join(module_trees[:-1])
         class_name = module_trees[-1]

--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -26,9 +26,16 @@ class SimpleLoss:
 
     def __init__(self, func_name: str, params: dict = {}):
         self.ignore_nan = params.get("ignore_nan", False)
+        
+        # This is the hotfix for the issue that the loss function is not found 
+        # > NameError: <allegro_pol.pol_loss.FoldedPolLoss object at 0x7fda9286fd90> type is not found in torch.nn module
+        module_trees = func_name.split(".")
+        parent_module = ".".join(module_trees[:-1])
+        class_name = module_trees[-1]
+
         func, _ = instantiate_from_cls_name(
-            torch.nn,
-            class_name=func_name,
+            eval(parent_module) if parent_module else torch.nn,
+            class_name=class_name,
             prefix="",
             positional_args=dict(reduction="none"),
             optional_args=params,

--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -36,7 +36,7 @@ class SimpleLoss:
         parent_module = ".".join(module_trees[:-1])
         class_name = module_trees[-1]
 
-        if parent_module:
+        if len(module_trees[:-1]) > 0:
             importlib.import_module(module_trees[0])
 
         func, _ = instantiate_from_cls_name(

--- a/nequip/train/_loss.py
+++ b/nequip/train/_loss.py
@@ -36,7 +36,8 @@ class SimpleLoss:
         parent_module = ".".join(module_trees[:-1])
         class_name = module_trees[-1]
 
-        importlib.import_module(module_trees[0])
+        if parent_module:
+            importlib.import_module(module_trees[0])
 
         func, _ = instantiate_from_cls_name(
             eval(parent_module) if parent_module else torch.nn,


### PR DESCRIPTION
This is the customized upstream fix for allegro-pol missing loss module. 
See https://github.com/mir-group/allegro-pol/pull/3 for detials.

## Description

This PR makes loss object construction more robust to make sure the example [config BaTiO3.yaml](https://github.com/mir-group/allegro-pol/blob/631de869fca91bdfc62f28df775cb01922eb1ef4/configs/BaTiO3.yaml) is runnable.


## How Has This Been Tested?

After this fix, `nequip-train configs/BaTiO3.yaml` can be executed without any problem.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read ["Contributing to NequIP"](../docs/dev/contributing.md).
- [x] My code follows the code style of this project and has been formatted using `black`.
- [ ] All new and existing tests passed, including on GPU (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] I have updated `CHANGELOG.md`.
- [ ] I have updated the documentation (if relevant).
