### PR TITLE
Allow model check to be skipped with `nequip-compile` via env var

### DIFF
--- a/nequip/scripts/compile.py
+++ b/nequip/scripts/compile.py
@@ -160,6 +160,12 @@ def main(args=None):
         type=str,
         default=[],
     )
+    parser.add_argument(
+        "--skip-dtype-check",
+        help="whether to skip the output dtype similarity check for the compiled model (default: False)",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     args = parser.parse_args(args=args)
 
     set_workflow_state("compile")
@@ -315,6 +321,7 @@ def main(args=None):
             output_path=str(args.output_path),
             inductor_configs=inductor_configs,
             seed=_COMPILE_SEED,
+            skip_dtype_check=args.skip_dtype_check,
         )
         logger.info(f"Exported model saved to {args.output_path}")
         set_workflow_state(None)

--- a/nequip/scripts/compile.py
+++ b/nequip/scripts/compile.py
@@ -316,7 +316,8 @@ def main(args=None):
             output_path=str(args.output_path),
             inductor_configs=inductor_configs,
             seed=_COMPILE_SEED,
-            skip_model_check=os.environ.get("NEQUIP_SKIP_COMPILED_MODEL_CHECK", "0") == "1",
+            skip_model_check=os.environ.get("NEQUIP_SKIP_COMPILED_MODEL_CHECK", "0")
+            == "1",
         )
         logger.info(f"Exported model saved to {args.output_path}")
         set_workflow_state(None)

--- a/nequip/scripts/compile.py
+++ b/nequip/scripts/compile.py
@@ -1,5 +1,6 @@
 # This file is a part of the `nequip` package. Please see LICENSE and README at the root for information on using it.
 import torch
+import os
 
 from ._workflow_utils import set_workflow_state
 from ._compile_utils import COMPILE_TARGET_DICT
@@ -160,12 +161,6 @@ def main(args=None):
         type=str,
         default=[],
     )
-    parser.add_argument(
-        "--skip-dtype-check",
-        help="whether to skip the output dtype similarity check for the compiled model (default: False)",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-    )
     args = parser.parse_args(args=args)
 
     set_workflow_state("compile")
@@ -321,7 +316,7 @@ def main(args=None):
             output_path=str(args.output_path),
             inductor_configs=inductor_configs,
             seed=_COMPILE_SEED,
-            skip_dtype_check=args.skip_dtype_check,
+            skip_model_check=os.environ.get("NEQUIP_SKIP_COMPILED_MODEL_CHECK", "0") == "1",
         )
         logger.info(f"Exported model saved to {args.output_path}")
         set_workflow_state(None)

--- a/nequip/scripts/compile.py
+++ b/nequip/scripts/compile.py
@@ -1,6 +1,5 @@
 # This file is a part of the `nequip` package. Please see LICENSE and README at the root for information on using it.
 import torch
-import os
 
 from ._workflow_utils import set_workflow_state
 from ._compile_utils import COMPILE_TARGET_DICT
@@ -316,8 +315,6 @@ def main(args=None):
             output_path=str(args.output_path),
             inductor_configs=inductor_configs,
             seed=_COMPILE_SEED,
-            skip_model_check=os.environ.get("NEQUIP_SKIP_COMPILED_MODEL_CHECK", "0")
-            == "1",
         )
         logger.info(f"Exported model saved to {args.output_path}")
         set_workflow_state(None)

--- a/nequip/utils/aot.py
+++ b/nequip/utils/aot.py
@@ -1,5 +1,6 @@
 # This file is a part of the `nequip` package. Please see LICENSE and README at the root for information on using it.
 import torch
+import os
 
 from nequip.nn.compile import ListInputOutputWrapper, DictInputOutputWrapper
 from nequip.data import AtomicDataDict
@@ -22,7 +23,6 @@ def aot_export_model(
     output_path: str,
     inductor_configs: Dict[str, Any] = {},
     seed: int = 1,
-    skip_model_check: bool = False,
 ) -> str:
     # === torch version check ===
     check_pt2_compile_compatibility()
@@ -60,7 +60,7 @@ def aot_export_model(
     assert out_path == output_path
 
     # === sanity check ===
-    if not skip_model_check:
+    if os.environ.get("NEQUIP_SKIP_AOTI_MODEL_CHECK", "0") == "0":
         aot_model = DictInputOutputWrapper(
             torch._inductor.aoti_load_package(out_path),
             input_fields,

--- a/nequip/utils/aot.py
+++ b/nequip/utils/aot.py
@@ -60,7 +60,7 @@ def aot_export_model(
     assert out_path == output_path
 
     # === sanity check ===
-    if os.environ.get("NEQUIP_SKIP_AOTI_MODEL_CHECK", "0") == "0":
+    if os.environ.get("NEQUIP_SKIP_AOTI_MODEL_CHECK", "0") != "1":
         aot_model = DictInputOutputWrapper(
             torch._inductor.aoti_load_package(out_path),
             input_fields,

--- a/nequip/utils/aot.py
+++ b/nequip/utils/aot.py
@@ -22,7 +22,7 @@ def aot_export_model(
     output_path: str,
     inductor_configs: Dict[str, Any] = {},
     seed: int = 1,
-    skip_dtype_check: bool = False,
+    skip_model_check: bool = False,
 ) -> str:
     # === torch version check ===
     check_pt2_compile_compatibility()
@@ -60,7 +60,7 @@ def aot_export_model(
     assert out_path == output_path
 
     # === sanity check ===
-    if not skip_dtype_check:
+    if not skip_model_check:
         aot_model = DictInputOutputWrapper(
             torch._inductor.aoti_load_package(out_path),
             input_fields,

--- a/nequip/utils/aot.py
+++ b/nequip/utils/aot.py
@@ -22,6 +22,7 @@ def aot_export_model(
     output_path: str,
     inductor_configs: Dict[str, Any] = {},
     seed: int = 1,
+    skip_dtype_check: bool = False,
 ) -> str:
     # === torch version check ===
     check_pt2_compile_compatibility()
@@ -59,19 +60,20 @@ def aot_export_model(
     assert out_path == output_path
 
     # === sanity check ===
-    aot_model = DictInputOutputWrapper(
-        torch._inductor.aoti_load_package(out_path),
-        input_fields,
-        output_fields,
-    )
-    test_model_output_similarity_by_dtype(
-        aot_model,
-        model,
-        {k: data[k] for k in input_fields},
-        model.model_dtype,
-        fields=output_fields,
-        error_message=_pt2_compile_error_message,
-    )
-    del aot_model
+    if not skip_dtype_check:
+        aot_model = DictInputOutputWrapper(
+            torch._inductor.aoti_load_package(out_path),
+            input_fields,
+            output_fields,
+        )
+        test_model_output_similarity_by_dtype(
+            aot_model,
+            model,
+            {k: data[k] for k in input_fields},
+            model.model_dtype,
+            fields=output_fields,
+            error_message=_pt2_compile_error_message,
+        )
+        del aot_model
 
     return out_path


### PR DESCRIPTION
This adds a `--skip-dtype-check` option to `nequip-compile` to skip the dtype similarity checks at the end of model compilation.

The motivation for this is that, when compiling on CPU at least, `test_model_output_similarity_by_dtype` spikes the memory demand. This prevents the use of `nequip-compile` on FasRC login nodes (which annoyingly have quite a low amount of RAM) due to OOM, which makes things a little bit awkward. Using this option, `nequip-compile` can run on the login nodes. Intended only really for power users / developers, when one is already confident there are no dtype issues with the models.