### PR TITLE
`wandb.watch()` callback fix

### DIFF
--- a/nequip/train/callbacks/wandb_watch.py
+++ b/nequip/train/callbacks/wandb_watch.py
@@ -25,7 +25,7 @@ class WandbWatch(Callback):
     ):
         self.log_freq = log_freq
         assert log in ["gradients", "parameters", "all", None]
-        self.log = log
+        self.wandb_log_setting = log  # use 'wandb_log_setting' as attr name to avoid conflict with LightningModule.log()
         self.log_graph = log_graph
 
     def on_train_start(
@@ -40,7 +40,7 @@ class WandbWatch(Callback):
         # see https://docs.wandb.ai/ref/python/watch/
         trainer.logger.watch(
             pl_module.model,
-            log=self.log,
+            log=self.wandb_log_setting,
             log_freq=self.log_freq,
             log_graph=self.log_graph,
         )


### PR DESCRIPTION
This is a small fix for handling the `log` setting for the `WandbWatch` callback. 
`log` is one of the input parameters for the `watch()` method, but should not be stored under `self.log` in the callback as this interferes with the `LightningModule.log()` method and causes failures. This PR changes the `log` setting to be stored under `self.wandb_log_setting`, along with a comment noting why this is. Tested and works well like this.