### PR TITLE
Add `exclude_keys` option to `NequIPLMDBDataset `

### DIFF
--- a/nequip/data/dataset/lmdb_dataset.py
+++ b/nequip/data/dataset/lmdb_dataset.py
@@ -125,7 +125,16 @@ class NequIPLMDBDataset(AtomicDataset):
                 data = txn.get(f"{idx}".encode("ascii"))
                 if data is None:
                     raise IndexError(f"Index {idx} is out of bounds for LMDB dataset.")
-                data_list.append(pickle.loads(data) if not self.exclude_keys else {k:v for k,v in pickle.loads(data).items() if k not in self.exclude_keys})
+                loaded_data = pickle.loads(data)
+                data_list.append(
+                    loaded_data
+                    if not self.exclude_keys
+                    else {
+                        k: v
+                        for k, v in loaded_data.items()
+                        if k not in self.exclude_keys
+                    }
+                )
         return data_list
 
     @classmethod

--- a/nequip/data/dataset/lmdb_dataset.py
+++ b/nequip/data/dataset/lmdb_dataset.py
@@ -81,13 +81,14 @@ class NequIPLMDBDataset(AtomicDataset):
     Args:
         file_path (str): path to LMDB file
         transforms (List[Callable]): list of data transforms
+        exclude_keys (List[str]): list of data keys to ignore
     """
 
     def __init__(
         self,
         file_path: str,
         transforms: List[Callable] = [],
-        exclude_keys: list[str] = [],
+        exclude_keys: List[str] = [],
     ):
         super().__init__(transforms=transforms)
         self.file_path = file_path
@@ -124,7 +125,7 @@ class NequIPLMDBDataset(AtomicDataset):
                 data = txn.get(f"{idx}".encode("ascii"))
                 if data is None:
                     raise IndexError(f"Index {idx} is out of bounds for LMDB dataset.")
-                data_list.append({k:v for k,v in pickle.loads(data).items() if k not in self.exclude_keys})
+                data_list.append(pickle.loads(data) if not self.exclude_keys else {k:v for k,v in pickle.loads(data).items() if k not in self.exclude_keys})
         return data_list
 
     @classmethod

--- a/nequip/data/dataset/lmdb_dataset.py
+++ b/nequip/data/dataset/lmdb_dataset.py
@@ -87,6 +87,7 @@ class NequIPLMDBDataset(AtomicDataset):
         self,
         file_path: str,
         transforms: List[Callable] = [],
+        exclude_keys: list[str] = [],
     ):
         super().__init__(transforms=transforms)
         self.file_path = file_path
@@ -100,6 +101,7 @@ class NequIPLMDBDataset(AtomicDataset):
             subdir=False,
         )
         self._length = self.get_metadata(NUM_FRAMES_METADATA_KEY)
+        self.exclude_keys = exclude_keys
 
         # Fallback to stat()['entries'] if no metadata to be backwards compatible
         if self._length is None:
@@ -122,7 +124,7 @@ class NequIPLMDBDataset(AtomicDataset):
                 data = txn.get(f"{idx}".encode("ascii"))
                 if data is None:
                     raise IndexError(f"Index {idx} is out of bounds for LMDB dataset.")
-                data_list.append(pickle.loads(data))
+                data_list.append({k:v for k,v in pickle.loads(data).items() if k not in self.exclude_keys})
         return data_list
 
     @classmethod


### PR DESCRIPTION
Feel free to close if this isn't wanted.
Just a drop-in addition for an `exclude_keys` option with `NequIPLMDBDataset` (useful if dealing with massive LMDB datasets where re-processing to remove certain keys can take a while). 
Tested and worked well for me.