### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyyaml",
     "importlib_metadata; python_version<'3.10'",
     "hydra-core",
-    "lightning",
+    "lightning>=2.0, !=2.6.2, !=2.6.3",
     "torchmetrics>=1.6.0",
     "requests"
 ]


### PR DESCRIPTION
lightning versions 2.6.2 and 2.6.3 were found to contain credential stealing code on install.