### PR TITLE
add per_type_coeffs option for weighted per-type force loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Most recent change on the top.
 
 ## Unreleased
 
+### Added
+- per-species force loss weighting: `per_type_coeffs` key on `MetricsManager` metrics, and `per_type_forces_coeffs` kwarg on `EnergyForceLoss` and `EnergyForceStressLoss` for emphasizing some atom types over others in the forces loss (weighted-mean aggregation over per-type MSEs)
+
 ## [0.18.0]
 
 ### Added

--- a/docs/guide/configuration/metrics.md
+++ b/docs/guide/configuration/metrics.md
@@ -105,12 +105,37 @@ trainer:
     monitor: ${monitored_metric}
 ```
 
+## Per-Species Force Loss Coefficients
+
+For systems with very heterogeneous species, it can help to emphasize the force errors on some atomic types over others. {class}`~nequip.train.EnergyForceLoss` and {class}`~nequip.train.EnergyForceStressLoss` accept an optional `per_type_forces_coeffs` dict for this purpose. These are loss-aggregation coefficients — not to be confused with model parameters.
+
+When supplied, the forces loss is computed per atom type and combined as a *weighted mean* `sum(c_i * mse_i) / sum(c_i)` instead of the default equal-mean over types. Equal coefficients reproduce the default behavior exactly.
+
+```yaml
+loss:
+  _target_: nequip.train.EnergyForceLoss
+  per_atom_energy: true
+  coeffs:
+    total_energy: 1.0
+    forces: 1.0
+  # Emphasize H force errors relative to heavier species
+  per_type_forces_coeffs:
+    H:  5.0
+    O:  1.0
+    P:  1.0
+    Cs: 0.01
+```
+
+The dict must contain a strictly positive coefficient for every type in `type_names` (no missing keys, no zeros, no negatives). To deemphasize a species, give it a small positive coefficient rather than `0`, since a force field with zero training signal on a species is rarely intended. Only the forces term is affected; per-structure terms (`total_energy`, `stress`) ignore this argument.
+
+Per-type breakdowns logged during training (e.g. `forces_mse_H`, `forces_mse_O`) are the raw per-species MSEs. The coefficients are applied only to the aggregated `forces_mse`.
+
 ## Advanced Usage: Custom MetricsManager
 
 For scenarios not covered by the simplified wrappers, you can use the full {class}`~nequip.train.MetricsManager` directly. Technical details and advanced examples are provided in the [`nequip.train.MetricsManager` API documentation](../../api/metrics.rst).
 
 Common advanced use cases include:
 - Custom field modifiers beyond {class}`~nequip.data.PerAtomModifier`
-- Per-type metrics (separate metrics for each atom type)
+- Per-type metrics (separate metrics for each atom type, optionally combined as a weighted mean via `per_type_coeffs`)
 - Custom metric types (e.g., {class}`~nequip.train.HuberLoss`, {class}`~nequip.train.StratifiedHuberForceLoss`)
 - Handling datasets with missing labels (using `ignore_nan: true`)

--- a/docs/guide/configuration/metrics.md
+++ b/docs/guide/configuration/metrics.md
@@ -130,6 +130,41 @@ The dict must contain a strictly positive coefficient for every type in `type_na
 
 Per-type breakdowns logged during training (e.g. `forces_mse_H`, `forces_mse_O`) are the raw per-species MSEs. The coefficients are applied only to the aggregated `forces_mse`.
 
+### Logging per-species force MAE and RMSE
+
+The loss only emits per-species MSE breakdowns (`forces_mse_H`, `forces_mse_O`, etc.). To also monitor per-species MAE and RMSE in physical units, the metrics wrapper accepts an `extra_metrics` list:
+
+```yaml
+val_metrics:
+  _target_: nequip.train.EnergyForceMetrics
+  coeffs:
+    per_atom_energy_mae: 1.0
+    forces_mae: 1.0
+  # Per-species force breakdown (observation-only; omit `coeff` so they
+  # don't enter `weighted_sum`).
+  extra_metrics:
+    - name: per_type_forces_mae
+      field: forces
+      metric:
+        _target_: nequip.train.MeanAbsoluteError
+      per_type: true
+    - name: per_type_forces_rmse
+      field: forces
+      metric:
+        _target_: nequip.train.RootMeanSquaredError
+      per_type: true
+
+# Reuse for train / test so all three log the same breakdown:
+train_metrics: ${training_module.val_metrics}
+test_metrics:  ${training_module.val_metrics}
+```
+
+This logs:
+- per-species values: `per_type_forces_mae_H`, `per_type_forces_mae_O`, `per_type_forces_mae_P`, `per_type_forces_mae_Cs`, and analogously for `_rmse`,
+- the equal-mean aggregate over species: `per_type_forces_mae` and `per_type_forces_rmse`.
+
+To include a per-species metric in the monitored `weighted_sum` (e.g. to early-stop on per-species RMSE), give the entry a non-null `coeff`. The snippet above omits `coeff`, leaving these as observation-only.
+
 ## Advanced Usage: Custom MetricsManager
 
 For scenarios not covered by the simplified wrappers, you can use the full {class}`~nequip.train.MetricsManager` directly. Technical details and advanced examples are provided in the [`nequip.train.MetricsManager` API documentation](../../api/metrics.rst).

--- a/nequip/train/metrics_manager.py
+++ b/nequip/train/metrics_manager.py
@@ -9,6 +9,7 @@ from .metrics import (
     MaximumAbsoluteError,
 )
 
+from collections.abc import Mapping
 from typing import Any, List, Dict, Union, Callable, Final, Optional
 
 _METRICS_MANAGER_INPUT_KEYS: Final[List[str]] = [
@@ -241,7 +242,7 @@ class MetricsManager(torch.nn.ModuleDict):
                     raise ValueError(
                         f"`per_type_coeffs` provided for `{name}` but `per_type` is not True; per-type coefficients require `per_type: true`."
                     )
-                if not isinstance(raw_coeffs, dict):
+                if not isinstance(raw_coeffs, Mapping):
                     raise TypeError(
                         f"`per_type_coeffs` must be a dict mapping type name to positive float, got {type(raw_coeffs).__name__}."
                     )

--- a/nequip/train/metrics_manager.py
+++ b/nequip/train/metrics_manager.py
@@ -17,6 +17,7 @@ _METRICS_MANAGER_INPUT_KEYS: Final[List[str]] = [
     "name",
     "coeff",
     "per_type",
+    "per_type_coeffs",
     "ignore_nan",
 ]
 
@@ -80,6 +81,16 @@ class MetricsManager(torch.nn.ModuleDict):
         Compute separate metrics for each atom type, then average them.
         Only valid for node fields (like ``forces``).
         Requires ``type_names`` parameter.
+
+    ``per_type_coeffs`` : ``Dict[str, float]``, optional
+        Per-type coefficients for combining per-type metrics into a single scalar.
+        Note: these are loss-aggregation coefficients
+        Requires ``per_type=True``. Must contain a strictly positive coefficient
+        for every type in ``type_names`` (no zeros, no negatives, no missing keys).
+        The aggregate becomes the weighted mean
+        ``sum(c_i * metric_i) / sum(c_i)`` instead of the equal-mean default;
+        equal coefficients reproduce the default exactly.
+        Example: ``{H: 5.0, O: 1.0, Cs: 0.5}`` emphasizes H force errors relative to O and Cs.
 
     ``ignore_nan`` : ``bool``, default=False
         Handle NaN values in target data by masking them out.
@@ -219,6 +230,45 @@ class MetricsManager(torch.nn.ModuleDict):
                     ptm_list.append(metric.clone())
                 metric = ptm_list
 
+            # == per_type_coeffs ==
+            # parse user-provided dict (or None) and align to type_names ordering.
+            # all types in `type_names` must appear with a strictly positive
+            # coefficient -- there is intentionally no shortcut for "ignore
+            # species X"
+            raw_coeffs = metric_dict.get("per_type_coeffs", None)
+            if raw_coeffs is not None:
+                if not per_type:
+                    raise ValueError(
+                        f"`per_type_coeffs` provided for `{name}` but `per_type` is not True; per-type coefficients require `per_type: true`."
+                    )
+                if not isinstance(raw_coeffs, dict):
+                    raise TypeError(
+                        f"`per_type_coeffs` must be a dict mapping type name to positive float, got {type(raw_coeffs).__name__}."
+                    )
+                type_names_set = set(self.type_names)
+                provided_set = set(raw_coeffs.keys())
+                unknown = provided_set - type_names_set
+                if unknown:
+                    raise ValueError(
+                        f"`per_type_coeffs` for `{name}` contains type names {sorted(unknown)} not in `type_names` {self.type_names}."
+                    )
+                missing = type_names_set - provided_set
+                if missing:
+                    raise ValueError(
+                        f"`per_type_coeffs` for `{name}` must specify a positive coefficient for every type in `type_names`; missing: {sorted(missing)}."
+                    )
+                coeffs_by_idx: List[float] = []
+                for tn in self.type_names:
+                    c = float(raw_coeffs[tn])
+                    if c <= 0:
+                        raise ValueError(
+                            f"`per_type_coeffs` entry for `{tn}` must be positive (got {c})."
+                        )
+                    coeffs_by_idx.append(c)
+                per_type_coeffs: Optional[List[float]] = coeffs_by_idx
+            else:
+                per_type_coeffs = None
+
             # === construct dict entry ===
             self.metrics.update(
                 {
@@ -227,6 +277,7 @@ class MetricsManager(torch.nn.ModuleDict):
                         "coeff": metric_dict.get("coeff", None),
                         "ignore_nan": ignore_nan,
                         "per_type": per_type,
+                        "per_type_coeffs": per_type_coeffs,
                     }
                 }
             )
@@ -272,7 +323,9 @@ class MetricsManager(torch.nn.ModuleDict):
                 preds_field, target_field = field(preds, target)
                 if per_type:
                     metric = 0
+                    coeffs: Optional[List[float]] = metric_params["per_type_coeffs"]
                     num_contributing_types = 0
+                    coeff_sum = 0.0
                     for type_idx, type_name in enumerate(self.type_names):
                         # index out each type
                         selector = torch.eq(
@@ -301,10 +354,19 @@ class MetricsManager(torch.nn.ModuleDict):
                         # account for batches without atom type
                         assert pt_metric.numel() == 1
                         if not torch.isnan(pt_metric):
-                            metric = metric + pt_metric
-                            num_contributing_types += 1
-                    assert num_contributing_types <= len(self.type_names)
-                    metric = metric / num_contributing_types
+                            if coeffs is None:
+                                metric = metric + pt_metric
+                                num_contributing_types += 1
+                            else:
+                                c = coeffs[type_idx]
+                                metric = metric + c * pt_metric
+                                coeff_sum += c
+                    if coeffs is None:
+                        assert num_contributing_types <= len(self.type_names)
+                        metric = metric / num_contributing_types
+                    else:
+                        # weighted mean over contributing types
+                        metric = metric / coeff_sum
                 else:
                     # mask out NaNs (based on target)
                     if ignore_nan:
@@ -340,14 +402,21 @@ class MetricsManager(torch.nn.ModuleDict):
         for metric_name, metric_params in self.metrics.items():
             if metric_params["per_type"]:
                 metric = 0
+                coeffs: Optional[List[float]] = metric_params["per_type_coeffs"]
                 for type_idx, type_name in enumerate(self.type_names):
                     ps_metric = self[metric_name][type_idx].compute()
                     ps_metric_name = (
                         prefix + "_".join([metric_name, type_name]) + suffix
                     )
                     metric_dict.update({ps_metric_name: ps_metric})
-                    metric = metric + ps_metric
-                metric = metric / len(self.type_names)
+                    if coeffs is None:
+                        metric = metric + ps_metric
+                    else:
+                        metric = metric + coeffs[type_idx] * ps_metric
+                if coeffs is None:
+                    metric = metric / len(self.type_names)
+                else:
+                    metric = metric / sum(coeffs)
             else:
                 metric = self[metric_name].compute()
             metric_dict.update({prefix + metric_name + suffix: metric})
@@ -413,6 +482,7 @@ def EnergyForceLoss(
         AtomicDataDict.FORCE_KEY: 1.0,
     },
     per_atom_energy: bool = True,
+    per_type_forces_coeffs: Optional[Dict[str, float]] = None,
     type_names: Optional[List[str]] = None,
     extra_metrics: Optional[List[Dict[str, Any]]] = None,
 ):
@@ -433,12 +503,28 @@ def EnergyForceLoss(
             coeffs:
               total_energy: 1.0
               forces: 1.0
+            # Optional: per-species coefficients for the forces loss.
+            per_type_forces_coeffs:
+              H:  5.0
+              O:  1.0
+              Cs: 0.5
 
     Args:
         coeffs (Dict[str, float]): ``dict`` that stores the relative weight of energy and forces to the overall loss (default ``{'total_energy': 1.0, 'forces': 1.0}``)
         per_atom_energy (bool, optional): whether to normalize the total energy by the number of atoms (default ``True``)
+        per_type_forces_coeffs (Dict[str, float], optional): if provided, the forces MSE becomes a per-type weighted mean. See the ``per_type_coeffs`` key on :class:`MetricsManager` for the dict format and validation rules. (default ``None``)
         extra_metrics (list of dict, optional): additional metric entries appended to the wrapper's defaults
     """
+
+    forces_entry: Dict[str, Any] = {
+        "name": "forces_mse",
+        "field": AtomicDataDict.FORCE_KEY,
+        "coeff": coeffs[AtomicDataDict.FORCE_KEY],
+        "metric": MeanSquaredError(),
+    }
+    if per_type_forces_coeffs is not None:
+        forces_entry["per_type"] = True
+        forces_entry["per_type_coeffs"] = per_type_forces_coeffs
 
     metrics = [
         {
@@ -451,12 +537,7 @@ def EnergyForceLoss(
             "coeff": coeffs[AtomicDataDict.TOTAL_ENERGY_KEY],
             "metric": MeanSquaredError(),
         },
-        {
-            "name": "forces_mse",
-            "field": AtomicDataDict.FORCE_KEY,
-            "coeff": coeffs[AtomicDataDict.FORCE_KEY],
-            "metric": MeanSquaredError(),
-        },
+        forces_entry,
     ]
     return MetricsManager(
         _with_extra_metrics(metrics, extra_metrics), type_names=type_names
@@ -594,6 +675,7 @@ def EnergyForceStressLoss(
         AtomicDataDict.STRESS_KEY: 1.0,
     },
     per_atom_energy: bool = True,
+    per_type_forces_coeffs: Optional[Dict[str, float]] = None,
     type_names: Optional[List[str]] = None,
     ignore_nan: Optional[Dict[str, bool]] = None,
     extra_metrics: Optional[List[Dict[str, Any]]] = None,
@@ -616,6 +698,11 @@ def EnergyForceStressLoss(
               total_energy: 1.0
               forces: 1.0
               stress: 1.0
+            # Optional: per-species coefficients for the forces loss.
+            per_type_forces_coeffs:
+              H:  5.0
+              O:  1.0
+              Cs: 0.5
             # if not all frames have stresses, one can populate the stress labels with NaN and set ignore_nan here:
             # ignore_nan:
             #   stress: true
@@ -623,11 +710,23 @@ def EnergyForceStressLoss(
     Args:
         coeffs (Dict[str, float]): ``dict`` that stores the relative weight of energy and forces to the overall loss (default ``{'total_energy': 1.0, 'forces': 1.0, 'stress': 1.0}``)
         per_atom_energy (bool, optional): whether to normalize the total energy by the number of atoms (default ``True``)
+        per_type_forces_coeffs (Dict[str, float], optional): if provided, the forces MSE becomes a per-type weighted mean. Applies to forces only; energy and stress are unaffected. See the ``per_type_coeffs`` key on :class:`MetricsManager` for the dict format and validation rules. (default ``None``)
         ignore_nan (Dict[str, bool], optional): ``dict`` that specifies whether to ignore NaN values for each field (default: all ``False``)
         extra_metrics (list of dict, optional): additional metric entries appended to the wrapper's defaults
     """
 
     ignore_nan = {} if ignore_nan is None else ignore_nan
+    forces_entry: Dict[str, Any] = {
+        "name": "forces_mse",
+        "field": AtomicDataDict.FORCE_KEY,
+        "coeff": coeffs[AtomicDataDict.FORCE_KEY],
+        "metric": MeanSquaredError(),
+        "ignore_nan": ignore_nan.get(AtomicDataDict.FORCE_KEY, False),
+    }
+    if per_type_forces_coeffs is not None:
+        forces_entry["per_type"] = True
+        forces_entry["per_type_coeffs"] = per_type_forces_coeffs
+
     metrics = [
         {
             "name": "per_atom_energy_mse" if per_atom_energy else "total_energy_mse",
@@ -640,13 +739,7 @@ def EnergyForceStressLoss(
             "metric": MeanSquaredError(),
             "ignore_nan": ignore_nan.get(AtomicDataDict.TOTAL_ENERGY_KEY, False),
         },
-        {
-            "name": "forces_mse",
-            "field": AtomicDataDict.FORCE_KEY,
-            "coeff": coeffs[AtomicDataDict.FORCE_KEY],
-            "metric": MeanSquaredError(),
-            "ignore_nan": ignore_nan.get(AtomicDataDict.FORCE_KEY, False),
-        },
+        forces_entry,
         {
             "name": "stress_mse",
             "field": AtomicDataDict.STRESS_KEY,

--- a/tests/unit/train/test_metrics_manager.py
+++ b/tests/unit/train/test_metrics_manager.py
@@ -218,6 +218,72 @@ class TestMetricsManager:
             metrics_dict["per_type_force_MSE"], (loss_ref_0 + loss_ref_1) / 2.0
         )
 
+    def test_per_type_coeffs(self, data):
+        pred, ref, _, _ = data
+        # first half data are type 1
+        mse_type1 = torch.square(
+            pred[AtomicDataDict.FORCE_KEY][:5] - ref[AtomicDataDict.FORCE_KEY][:5]
+        ).mean()
+        mse_type0 = torch.square(
+            pred[AtomicDataDict.FORCE_KEY][5:] - ref[AtomicDataDict.FORCE_KEY][5:]
+        ).mean()
+
+        def mm_with(weights):
+            return MetricsManager(
+                [
+                    {
+                        "field": AtomicDataDict.FORCE_KEY,
+                        "per_type": True,
+                        "per_type_coeffs": weights,
+                        "metric": MeanSquaredError(),
+                        "name": "per_type_force_MSE",
+                    }
+                ],
+                type_names=["0", "1"],
+            )
+
+        # equal weights reproduce the equal-mean per_type behavior
+        out = mm_with({"0": 1.0, "1": 1.0})(pred, ref)
+        torch.testing.assert_close(
+            out["per_type_force_MSE"], (mse_type0 + mse_type1) / 2.0
+        )
+
+        # non-equal weights produce a weighted mean
+        out = mm_with({"0": 10.0, "1": 1.0})(pred, ref)
+        torch.testing.assert_close(
+            out["per_type_force_MSE"],
+            (10.0 * mse_type0 + 1.0 * mse_type1) / 11.0,
+        )
+
+    @pytest.mark.parametrize(
+        "weights,per_type,err_type,err_match",
+        [
+            # `per_type_coeffs` set but `per_type` flag missing
+            ({"0": 1.0, "1": 1.0}, False, ValueError, "require `per_type: true`"),
+            # extra key not in type_names
+            ({"0": 1.0, "1": 1.0, "Xx": 2.0}, True, ValueError, "not in `type_names`"),
+            # missing a type
+            ({"0": 1.0}, True, ValueError, "missing"),
+            # zero is rejected (typo guard)
+            ({"0": 2.0, "1": 0.0}, True, ValueError, "must be positive"),
+            # negative is rejected
+            ({"0": -1.0, "1": 1.0}, True, ValueError, "must be positive"),
+            # not a dict
+            ([1.0, 2.0], True, TypeError, "must be a dict"),
+        ],
+    )
+    def test_per_type_coeffs_validation(self, weights, per_type, err_type, err_match):
+        spec = {
+            "field": AtomicDataDict.FORCE_KEY,
+            "per_type_coeffs": weights,
+            "metric": MeanSquaredError(),
+            "name": "per_type_force_MSE",
+        }
+        if per_type:
+            spec["per_type"] = True
+        with pytest.raises(err_type, match=err_match):
+            MetricsManager([spec], type_names=["0", "1"])
+
     def test_per_atom(self, data):
         pred, ref, pred2, ref2 = data
         mm = MetricsManager(
@@ -713,6 +779,32 @@ class TestMetricsManagerBuilders:
         MSE = torch.mean((pred[property_key] - ref[property_key]) ** 2)
         RMSE = torch.sqrt(MSE)
         return RMSE
+
+    def test_EnergyForceLoss_per_type_forces_coeffs(self, data):
+        """Verify the `per_type_forces_coeffs` kwarg is routed to the forces metric only."""
+        pred, ref, _, _ = data
+        # first half data are type 1
+        mse_type1 = torch.square(
+            pred[AtomicDataDict.FORCE_KEY][:5] - ref[AtomicDataDict.FORCE_KEY][:5]
+        ).mean()
+        mse_type0 = torch.square(
+            pred[AtomicDataDict.FORCE_KEY][5:] - ref[AtomicDataDict.FORCE_KEY][5:]
+        ).mean()
+        mm = EnergyForceLoss(
+            coeffs={
+                AtomicDataDict.TOTAL_ENERGY_KEY: 1.0,
+                AtomicDataDict.FORCE_KEY: 1.0,
+            },
+            per_atom_energy=False,
+            per_type_forces_coeffs={"0": 4.0, "1": 1.0},
+            type_names=["0", "1"],
+        )
+        out = mm(pred, ref)
+        torch.testing.assert_close(
+            out["forces_mse"], (4.0 * mse_type0 + 1.0 * mse_type1) / 5.0
+        )
+        # per-type breakdowns are also logged
+        assert "forces_mse_0" in out and "forces_mse_1" in out
 
     def test_invalid_EF_coeff_key_triggers_assert(self):
         with pytest.raises(AssertionError):


### PR DESCRIPTION
## Description
Adds an optional `per_type_coeffs` key on `MetricsManager` metric entries and a `per_type_forces_coeffs` convenience kwarg on `EnergyForceLoss` and `EnergyForceStressLoss`. When supplied, the forces loss becomes the weighted mean of per-species MSEs: `sum(c_i * mse_i) / sum(c_i)`. Equal coefficients reproduce the current `per_type=true` equal-mean behavior exactly.

The low-level `per_type_coeffs` key generically handles weighting for any node field, while `per_type_forces_coeffs` acts as a convenience wrapper on standard loss classes (`EnergyForceLoss` and `EnergyForceStressLoss`) to unambiguously target the forces metric.

## Motivation and Context
Heterogeneous systems often contain one or two species that dominate the underlying physics. For ion conductors, force accuracy on the mobile ions is more important for resolving transport dynamics than on the largely immobile ions.

This change adds a per-type coefficient vector that weights the aggregation. The interface is purely additive: existing configs (with or without `per_type=true`) behave identically. Equal coefficients reproduce the current `per_type=true` mean exactly.

## How Has This Been Tested?
**Unit tests added** (3 functions, 8 instances total):
- `test_per_type_coeffs` — math correctness: equal coefficients reproduce the existing `per_type=true` mean exactly; non-equal coefficients produce `sum(c_i·mse_i) / sum(c_i)`.
- `test_per_type_coeffs_validation` — 6 parametrized error cases (missing `per_type`, unknown key, missing key, zero, negative, non-dict).
- `test_EnergyForceLoss_per_type_forces_coeffs` — wrapper routes the kwarg onto the forces metric only.

**Runs (Python 3.11, torch 2.12, lightning 2.6, CPU):**
- `pytest tests/unit/train/test_metrics_manager.py` — 460 passed (452 baseline + 8 new).
- `pytest tests/unit/` — 6349 passed; 32 errors in `test_ase_compile[...aotinductor...]` are pre-existing Apple Silicon MPS / float64 failures, unrelated (also fail on `main`).
- `pre-commit` — clean.
- end-to-end `nequip-train` run on A100-mig GPU.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read ["Contributing to NequIP"](../docs/dev/contributing.md).
- [x] My code follows the code style of this project and has been formatted using `black`.
- [x] All new and existing tests passed, including on GPU (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] I have updated `CHANGELOG.md`.
- [x] I have updated the documentation (if relevant).

