### PR TITLE
fix: detach tensors before passing to LAMMPS in ML-IAP wrapper

### DIFF
--- a/nequip/integrations/lammps_mliap/lmp_mliap_wrapper.py
+++ b/nequip/integrations/lammps_mliap/lmp_mliap_wrapper.py
@@ -5,9 +5,9 @@ import tempfile
 import os
 from pathlib import Path
 
-from nequip.data import AtomicDataDic
+from nequip.data import AtomicDataDict
 from nequip.data.transforms.neighborlist import NeighborListPruneTransform
-from nequip.nn import graph_mode
+from nequip.nn import graph_model
 from nequip.model.saved_models.load_utils import load_saved_model
 from nequip.model.modify_utils import get_all_modifiers, modify
 from nequip.model.utils import _EAGER_MODEL_KEY

--- a/nequip/integrations/lammps_mliap/lmp_mliap_wrapper.py
+++ b/nequip/integrations/lammps_mliap/lmp_mliap_wrapper.py
@@ -5,9 +5,9 @@ import tempfile
 import os
 from pathlib import Path
 
-from nequip.data import AtomicDataDict
+from nequip.data import AtomicDataDic
 from nequip.data.transforms.neighborlist import NeighborListPruneTransform
-from nequip.nn import graph_model
+from nequip.nn import graph_mode
 from nequip.model.saved_models.load_utils import load_saved_model
 from nequip.model.modify_utils import get_all_modifiers, modify
 from nequip.model.utils import _EAGER_MODEL_KEY
@@ -243,9 +243,9 @@ class NequIPLAMMPSMLIAPWrapper(MLIAPUnified):
 
         # update LAMMPS variables
         lmp_eatoms = torch.as_tensor(lmp_data.eatoms)
-        lmp_eatoms.copy_(nequip_atomic_energies)
-        lmp_data.energy = nequip_total_energy
-        lmp_data.update_pair_forces_gpu(edge_forces)
+        lmp_eatoms.copy_(nequip_atomic_energies.detach())
+        lmp_data.energy = nequip_total_energy.detach()
+        lmp_data.update_pair_forces_gpu(edge_forces.detach())
 
     def compute_descriptors(self, lmp_data):
         pass


### PR DESCRIPTION
(maybe) fixes mir-group/allegro#133

All three tensors passed to LAMMPS at the end of `compute_forces` still carry `requires_grad=True` -`nequip_atomic_energies` and `nequip_total_energy` because they're downstream of `edge_vectors` which has `requires_grad_(True)` set on line 221, and `edge_forces` because it comes from `torch.autograd.grad`.

When thermostats like `fix langevin` add random and drag forces directly to the per-atom force array in-place after each force evaluation, the in-place modification can corrupt PyTorch's computational graph if those arrays are still attached to it. This explains the temperature explosion to 100K+ observed in the linked issue with `fix langevin` but not with `fix nvt`, since Nosé-Hoover modifies velocities rather than the force array directly.

The `UserWarning: Converting a tensor with requires_grad=True to a scalar` on line 178 is a symptom of the same issue.

This fix adds `.detach()` before handing tensors to LAMMPS. It has no effect on correctness since gradients are never needed past this point, and no effect on performance.