### PR TITLE
Docs: Make TP kernels more visible and a minor ASE link fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
     "lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
+    "ase": ("https://docs.ase-lib.org/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "e3nn": ("https://docs.e3nn.org/en/stable/", None),
     "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),

--- a/docs/guide/getting-started/workflow.md
+++ b/docs/guide/getting-started/workflow.md
@@ -155,6 +155,7 @@ nequip-compile \
   path/to/compiled_model.nequip.pth \
   --device [cpu|cuda] \
   --mode torchscript
+  # --modifiers enable_OpenEquivariance  # recommended GPU kernel acceleration (NequIP); use enable_CuEquivariance for Allegro
 ```
 
 To compile a model with AOTInductor:
@@ -165,6 +166,16 @@ nequip-compile \
   --device [cpu|cuda] \
   --mode aotinductor \
   --target [ase|pair_nequip|pair_allegro|...]
+  # --modifiers enable_OpenEquivariance  # recommended GPU kernel acceleration (NequIP); use enable_CuEquivariance for Allegro
+```
+
+```{important}
+We strongly recommend enabling the [GPU tensor-product kernel modifiers](../accelerations/gpu_kernel_modifiers.md) when compiling models on GPU. These greatly accelerate the model and reduce memory demand. Enable them with `nequip-compile` using the `--modifiers` flag:
+
+- **[OpenEquivariance](../accelerations/openequivariance.md)** for **NequIP** models: `--modifiers enable_OpenEquivariance`
+- **[CuEquivariance](../accelerations/cuequivariance.md)** for **Allegro** models: `--modifiers enable_CuEquivariance`
+
+For further speed-ups where appropriate (e.g. often permissible for MD simulations), [TF32 mixed-precision](../accelerations/precision.md#tf32-at-inference) can also be enabled at compile time by adding the `--tf32` flag.
 ```
 
 AOTInductor requires access to compilers like `gcc` and `nvcc` when running `nequip-compile`. Specifically, C++17 support is required, which requires `gcc` version 8 or higher (preferably >=11 where C++17 is the default). Without the proper compiler version, you may encounter errors such as `C++ compile error`, issues involving the `filesystem` standard library, or even `Segmentation fault (core dumped)`. You can check your `gcc` version with `gcc --version`, and may need to upgrade or load a specific module on your HPC system to get the required version before running `nequip-compile`.
@@ -193,7 +204,8 @@ nequip-compile \
   path/to/compiled_model.nequip.pt2 \
   --device cuda \
   --mode aotinductor \
-  --target ase
+  --target ase \
+  --modifiers enable_OpenEquivariance  # recommended GPU kernel acceleration (NequIP); use enable_CuEquivariance for Allegro
 ```
 
 The format is `nequip.net:group-name/model-name:version`, where you can find the full model ID on the model's page at [nequip.net](https://www.nequip.net/).


### PR DESCRIPTION
This docs update shows the TP kernel modifiers on the main NequIP workflow page (to try ensure users are aware of the easily added (and recommended) accelerations), with links to more detailed discussion on their own docs pages, as well as a minor fix for the updated ASE docs link.