### PR TITLE
Add `map_location="cpu"` to `load_from_checkpoint`

### DIFF
--- a/nequip/model/saved_models/checkpoint.py
+++ b/nequip/model/saved_models/checkpoint.py
@@ -77,7 +77,7 @@ def ModelFromCheckpoint(checkpoint_path: str, compile_mode: str = _EAGER_MODEL_K
     # ensure that model is built with correct `compile_mode`
     with override_model_compile_mode(compile_mode):
         lightning_module = training_module.load_from_checkpoint(
-            checkpoint_path, weights_only=False
+            checkpoint_path, map_location="cpu", weights_only=False
         )
 
     model = lightning_module.evaluation_model


### PR DESCRIPTION
Minor fix, using `map_location="cpu"` with `load_from_checkpoint`, matching the behaviour elsewhere in `nequip`. Checked and this seems to be the only missing case.

Avoids an issue where e.g. on an 8-rank DDP job, all 8 models load on GPU 0 first (using the `cuda: 0` device tag from the saved model), which causes a hang on startup.